### PR TITLE
Allow custom name for SubmarinerConfig

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	SubmarinerAddOnName  = "submariner"
-	SubmarinerConfigName = "submariner"
+	SubmarinerConfigName = "sample-submariner-config"
 )
 
 const (

--- a/pkg/hub/submarineragent/controller.go
+++ b/pkg/hub/submarineragent/controller.go
@@ -155,10 +155,6 @@ func NewSubmarinerAgentController(
 			// TODO: we may consider to use addon to set up the submariner env on the managed cluster instead of
 			// using manifestwork, one problem should be considered - how to get the cloud credentials
 			accessor, _ := meta.Accessor(obj)
-			if accessor.GetName() != helpers.SubmarinerConfigName {
-				return ""
-			}
-
 			return accessor.GetNamespace() + "/" + accessor.GetName()
 		}, configInformer.Informer()).
 		WithInformersQueueKeyFunc(func(obj runtime.Object) string {
@@ -202,7 +198,7 @@ func (c *submarinerAgentController) sync(ctx context.Context, syncCtx factory.Sy
 			return err
 		}
 
-		config, err := c.configLister.SubmarinerConfigs(name).Get(helpers.SubmarinerConfigName)
+		config, err := c.configLister.SubmarinerConfigs(namespace).Get(name)
 		if errors.IsNotFound(err) {
 			// only sync the managed cluster
 			return c.syncManagedCluster(ctx, managedCluster.DeepCopy(), nil)

--- a/pkg/spoke/submarineragent/config_controller.go
+++ b/pkg/spoke/submarineragent/config_controller.go
@@ -60,6 +60,7 @@ type submarinerConfigController struct {
 	clusterName          string
 	cloudProviderFactory cloud.ProviderFactory
 	onSyncDefer          func()
+	configName           string
 }
 
 type SubmarinerConfigControllerInput struct {
@@ -73,6 +74,7 @@ type SubmarinerConfigControllerInput struct {
 	Recorder             events.Recorder
 	// This is a hook for unit tests to invoke a defer (specifically GinkgoRecover) when the sync function is called.
 	OnSyncDefer func()
+	configName           string
 }
 
 // NewSubmarinerConfigController returns an instance of submarinerAgentConfigController.
@@ -86,6 +88,7 @@ func NewSubmarinerConfigController(input *SubmarinerConfigControllerInput) facto
 		clusterName:          input.ClusterName,
 		cloudProviderFactory: input.CloudProviderFactory,
 		onSyncDefer:          input.OnSyncDefer,
+		configName:           input.configName,
 	}
 
 	return factory.New().
@@ -97,7 +100,7 @@ func NewSubmarinerConfigController(input *SubmarinerConfigControllerInput) facto
 		WithFilteredEventsInformers(func(obj interface{}) bool {
 			metaObj := obj.(metav1.Object)
 
-			return metaObj.GetName() == helpers.SubmarinerConfigName
+			return metaObj.GetName() == c.configName
 		}, input.ConfigInformer.Informer()).
 		WithFilteredEventsInformers(func(obj interface{}) bool {
 			metaObj := obj.(metav1.Object)
@@ -127,7 +130,7 @@ func (c *submarinerConfigController) sync(ctx context.Context, syncCtx factory.S
 		return err
 	}
 
-	config, err := c.configLister.SubmarinerConfigs(c.clusterName).Get(helpers.SubmarinerConfigName)
+	config, err := c.configLister.SubmarinerConfigs(c.clusterName).Get(c.configName)
 	if apiErrors.IsNotFound(err) {
 		// the config not found, could be deleted, do nothing
 		return nil


### PR DESCRIPTION
This PR makes it possible to use a custom name for `SubmarinerConfig` rather than hard-coded `submariner` name.

Closes: https://github.com/open-cluster-management/submariner-addon/issues/221
Signed-Off-By: Janki Chhatbar <jchhatba@redhat.com>