### PR TITLE
Use os.ReadFile instead of deprecated ioutil

### DIFF
--- a/pkg/resource/namespace.go
+++ b/pkg/resource/namespace.go
@@ -1,11 +1,11 @@
 package resource
 
-import "io/ioutil"
+import "os"
 
 // GetCurrentNamespace returns the current namespace from file system,
 // if the namespace is not found, it returns the defaultNamespace.
 func GetCurrentNamespace(defaultNamespace string) string {
-	nsBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		return defaultNamespace
 	}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -3,7 +3,7 @@ package util
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"time"
 
@@ -37,7 +37,7 @@ var HubKubeConfigPath = path.Join("/tmp", "submaddon-integration-test", "kubecon
 
 // on prow env, the /var/run/secrets/kubernetes.io/serviceaccount/namespace can be found.
 func GetCurrentNamespace(kubeClient kubernetes.Interface, defaultNamespace string) (string, error) {
-	nsBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		if _, err := kubeClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
... as recommended by the Go developers, and required by our updated
linting setup.

Signed-off-by: Stephen Kitt <skitt@redhat.com>