### PR TITLE
Install brokers.submariner.io CRD

### DIFF
--- a/pkg/hub/submarinerbroker/brokerCRDsController.go
+++ b/pkg/hub/submarinerbroker/brokerCRDsController.go
@@ -22,6 +22,7 @@ const (
 
 var staticCRDFiles = []string{
 	"manifests/submariner.io_clusters_crd.yaml",
+	"manifests/submariner.io_brokers_crd.yaml",
 	"manifests/submariner.io_endpoints_crd.yaml",
 	"manifests/submariner.io_gateways_crd.yaml",
 	"manifests/submariner.io_lighthouse.serviceimports_crd.yaml",

--- a/pkg/hub/submarinerbroker/manifests/submariner.io_brokers_crd.yaml
+++ b/pkg/hub/submarinerbroker/manifests/submariner.io_brokers_crd.yaml
@@ -1,0 +1,69 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: brokers.submariner.io
+  ownerReferences:
+  - apiVersion: apiextensions.k8s.io/v1
+    controller: true
+    blockOwnerDeletion: true
+    kind: CustomResourceDefinition
+    name: submarinerconfigs.submarineraddon.open-cluster-management.io
+    uid: {{ .ConfigCRDUID }}
+spec:
+  group: submariner.io
+  names:
+    kind: Broker
+    listKind: BrokerList
+    plural: brokers
+    singular: broker
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Broker is the Schema for the brokers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BrokerSpec defines the desired state of Broker.
+            properties:
+              components:
+                items:
+                  type: string
+                type: array
+              defaultCustomDomains:
+                items:
+                  type: string
+                type: array
+              defaultGlobalnetClusterSize:
+                type: integer
+              globalnetCIDRRange:
+                type: string
+              globalnetEnabled:
+                type: boolean
+            type: object
+          status:
+            description: BrokerStatus defines the observed state of Broker
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
This PR installs the brokers CRD which will be used in subsequent
PRs to support Gloalnet use-cases.

Related to: https://github.com/submariner-io/enhancements/issues/51
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>