### PR TITLE
Create ClusterRole to allow brokers.submariner.io object

### DIFF
--- a/deploy/config/rbac/brokers-submariner-io-cr.yaml
+++ b/deploy/config/rbac/brokers-submariner-io-cr.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: access-to-brokers-submariner-crd
+rules:
+  - apiGroups: ["submariner.io"]
+    resources: ["brokers"]
+    verbs: ["create", "get", "update"]

--- a/deploy/config/rbac/kustomization.yaml
+++ b/deploy/config/rbac/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
   - cluster_role.yaml
   - cluster_role_binding.yaml
+  - brokers-submariner-io-cr.yaml


### PR DESCRIPTION
This PR installs a ClusterRole which when associated with a
roleBinding will allow the respective user to create/update
the brokers.submariner.io object. The cluster admin is
expected to assign the roleBinding to the ManagedClusterSetAdmin
who is interested in installing Submariner addon on the
managedClusters in the clusterSet.

Related to: https://github.com/submariner-io/enhancements/issues/51
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>