### PR TITLE
Update vendor/modules.txt

### DIFF
--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -649,8 +649,6 @@ golang.org/x/tools/internal/typeparams
 ## explicit; go 1.11
 golang.org/x/xerrors
 golang.org/x/xerrors/internal
-# gomodules.xyz/jsonpatch/v2 v2.2.0
-## explicit; go 1.12
 # google.golang.org/api v0.68.0
 ## explicit; go 1.11
 google.golang.org/api/compute/v1


### PR DESCRIPTION
This somehow ended up with an extra reference to jsonpatch after
commit 2721b564cf62 ("Bump to the latest Submariner operator").

Re-running "go mod vendor" drops the reference.

Signed-off-by: Stephen Kitt <skitt@redhat.com>