### PR TITLE
Add InstallPlan configuration to SubmarinerConfig

### DIFF
--- a/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -97,6 +97,9 @@ spec:
                   channel:
                     description: Channel represents the channel of a submariner subscription.
                     type: string
+                  installPlanApproval:
+                    description: InstallPlanApproval determines whether subscription installation plans are applied automatically.
+                    type: string
                   source:
                     default: redhat-operators
                     description: Source represents the catalog source of a submariner subscription. The default value is redhat-operators

--- a/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
+++ b/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
@@ -97,6 +97,9 @@ spec:
                   channel:
                     description: Channel represents the channel of a submariner subscription.
                     type: string
+                  installPlanApproval:
+                    description: InstallPlanApproval determines whether subscription installation plans are applied automatically.
+                    type: string
                   source:
                     default: redhat-operators
                     description: Source represents the catalog source of a submariner subscription. The default value is redhat-operators

--- a/pkg/apis/submarinerconfig/v1alpha1/types.go
+++ b/pkg/apis/submarinerconfig/v1alpha1/types.go
@@ -96,6 +96,10 @@ type SubscriptionConfig struct {
 	// StartingCSV represents the startingCSV of a submariner subscription.
 	// +optional
 	StartingCSV string `json:"startingCSV,omitempty"`
+
+	// InstallPlanApproval determines whether subscription installation plans are applied automatically.
+	// +optional
+	InstallPlanApproval string `json:"installPlanApproval,omitempty"`
 }
 
 type SubmarinerImagePullSpecs struct {

--- a/pkg/apis/submarinerconfig/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/pkg/apis/submarinerconfig/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -99,11 +99,12 @@ func (SubmarinerImagePullSpecs) SwaggerDoc() map[string]string {
 }
 
 var map_SubscriptionConfig = map[string]string{
-	"":                "SubscriptionConfig contains configuration specified for a submariner subscription.",
-	"source":          "Source represents the catalog source of a submariner subscription. The default value is redhat-operators",
-	"sourceNamespace": "SourceNamespace represents the catalog source namespace of a submariner subscription. The default value is openshift-marketplace",
-	"channel":         "Channel represents the channel of a submariner subscription.",
-	"startingCSV":     "StartingCSV represents the startingCSV of a submariner subscription.",
+	"":                    "SubscriptionConfig contains configuration specified for a submariner subscription.",
+	"source":              "Source represents the catalog source of a submariner subscription. The default value is redhat-operators",
+	"sourceNamespace":     "SourceNamespace represents the catalog source namespace of a submariner subscription. The default value is openshift-marketplace",
+	"channel":             "Channel represents the channel of a submariner subscription.",
+	"startingCSV":         "StartingCSV represents the startingCSV of a submariner subscription.",
+	"installPlanApproval": "InstallPlanApproval determines whether subscription installation plans are applied automatically.",
 }
 
 func (SubscriptionConfig) SwaggerDoc() map[string]string {

--- a/pkg/hub/submarineragent/manifests/operator/submariner-operator-subscription.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner-operator-subscription.yaml
@@ -7,7 +7,7 @@ spec:
 {{- if .CatalogChannel }}
   channel: {{ .CatalogChannel }}
 {{- end}}
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .InstallPlanApproval }}
   name: {{ .CatalogName }}
   source: {{ .CatalogSource }}
   sourceNamespace: {{ .CatalogSourceNamespace }}

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo.go
@@ -57,6 +57,7 @@ type SubmarinerBrokerInfo struct {
 	IPSecIKEPort              int
 	IPSecNATTPort             int
 	InstallationNamespace     string
+	InstallPlanApproval       string
 	BrokerAPIServer           string
 	BrokerNamespace           string
 	BrokerToken               string
@@ -96,6 +97,7 @@ func Get(
 		CatalogSource:          defaultCatalogSource,
 		CatalogSourceNamespace: defaultCatalogSourceNamespace,
 		InstallationNamespace:  defaultInstallationNamespace,
+		InstallPlanApproval:    "Automatic",
 	}
 
 	if len(installationNamespace) != 0 {
@@ -164,6 +166,10 @@ func applySubmarinerConfig(
 
 	if submarinerConfig.Spec.SubscriptionConfig.StartingCSV != "" {
 		brokerInfo.CatalogStartingCSV = submarinerConfig.Spec.SubscriptionConfig.StartingCSV
+	}
+
+	if submarinerConfig.Spec.SubscriptionConfig.InstallPlanApproval != "" {
+		brokerInfo.InstallPlanApproval = submarinerConfig.Spec.SubscriptionConfig.InstallPlanApproval
 	}
 
 	if submarinerConfig.Spec.ImagePullSpecs.SubmarinerImagePullSpec != "" {


### PR DESCRIPTION
This adds an InstallPlanApproval entry to the SubscriptionConfig
object in SubmarinerConfig, allowing the subscription's
InstallPlanApproval entry to be configured.

Fixes: #270
Signed-off-by: Stephen Kitt <skitt@redhat.com>
(cherry picked from commit 4f1fafbb8cf77707a6e77f59cb24a460ec40e441)