### PR TITLE
Make dedicated g/w node default in GCP

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -75,7 +75,7 @@ func (f *providerFactory) Get(managedClusterInfo configv1alpha1.ManagedClusterIn
 	case "GCP":
 		return gcp.NewGCPProvider(f.restMapper, f.kubeClient, f.dynamicClient, f.hubKubeClient, eventsRecorder,
 			region, infraID, clusterName, config.Spec.CredentialsSecret.Name,
-			"", config.Spec.IPSecNATTPort, config.Spec.NATTDiscoveryPort, config.Spec.Gateways)
+			config.Spec.GatewayConfig.GCP.InstanceType, config.Spec.IPSecNATTPort, config.Spec.NATTDiscoveryPort, config.Spec.Gateways)
 	}
 
 	return &defaultProvider{}, nil

--- a/pkg/cloud/gcp/gcp.go
+++ b/pkg/cloud/gcp/gcp.go
@@ -90,7 +90,7 @@ func NewGCPProvider(
 	k8sClient := k8s.NewInterface(kubeClient)
 
 	gwDeployer := cloudpreparegcp.NewOcpGatewayDeployer(cloudInfo, msDeployer, instanceType,
-		"", false, k8sClient)
+		"", true, k8sClient)
 
 	return &gcpProvider{
 		infraID:           infraID,

--- a/pkg/hub/submarineraddonagent/manifests/clusterrole.yaml
+++ b/pkg/hub/submarineraddonagent/manifests/clusterrole.yaml
@@ -15,3 +15,6 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch", "update", "patch"]
+- apiGroups: ["machine.openshift.io"]
+  resources: ["machinesets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
* Makes the dedicated gateway node as the default option in GCP.

Signed-off-by: Aswin Suryanarayanan <aswinsuryan@gmail.com>