### PR TITLE
Allow Globalnet metrics port while preparing cloud

### DIFF
--- a/pkg/cloud/aws/aws.go
+++ b/pkg/cloud/aws/aws.go
@@ -124,7 +124,8 @@ func (a *awsProvider) PrepareSubmarinerClusterEnv() error {
 	if err := a.cloudPrepare.PrepareForSubmariner(cpapi.PrepareForSubmarinerInput{
 		InternalPorts: []cpapi.PortSpec{
 			{Port: constants.SubmarinerRoutePort, Protocol: "udp"},
-			{Port: constants.SubmarinerMetricsPort, Protocol: "tcp"},
+			{Port: constants.SubmarinerGatewayMetricsPort, Protocol: "tcp"},
+			{Port: constants.SubmarinerGlobalnetMetricsPort, Protocol: "tcp"},
 		},
 	}, a.reporter); err != nil {
 		return err

--- a/pkg/cloud/gcp/gcp.go
+++ b/pkg/cloud/gcp/gcp.go
@@ -31,15 +31,16 @@ const (
 )
 
 type gcpProvider struct {
-	infraID           string
-	nattPort          uint16
-	routePort         string
-	metricsPort       uint16
-	cloudPrepare      api.Cloud
-	reporter          api.Reporter
-	gwDeployer        api.GatewayDeployer
-	gateways          int
-	nattDiscoveryPort int64
+	infraID              string
+	nattPort             uint16
+	routePort            string
+	gatewayMetricsPort   uint16
+	globalnetMetricsPort uint16
+	cloudPrepare         api.Cloud
+	reporter             api.Reporter
+	gwDeployer           api.GatewayDeployer
+	gateways             int
+	nattDiscoveryPort    int64
 }
 
 func NewGCPProvider(
@@ -93,15 +94,16 @@ func NewGCPProvider(
 		"", false, k8sClient)
 
 	return &gcpProvider{
-		infraID:           infraID,
-		nattPort:          uint16(nattPort),
-		routePort:         strconv.Itoa(constants.SubmarinerRoutePort),
-		metricsPort:       constants.SubmarinerMetricsPort,
-		cloudPrepare:      cloudPrepare,
-		gwDeployer:        gwDeployer,
-		reporter:          reporter.NewEventRecorderWrapper("GCPCloudProvider", eventRecorder),
-		nattDiscoveryPort: int64(nattDiscoveryPort),
-		gateways:          gateways,
+		infraID:              infraID,
+		nattPort:             uint16(nattPort),
+		routePort:            strconv.Itoa(constants.SubmarinerRoutePort),
+		gatewayMetricsPort:   constants.SubmarinerGatewayMetricsPort,
+		globalnetMetricsPort: constants.SubmarinerGlobalnetMetricsPort,
+		cloudPrepare:         cloudPrepare,
+		gwDeployer:           gwDeployer,
+		reporter:             reporter.NewEventRecorderWrapper("GCPCloudProvider", eventRecorder),
+		nattDiscoveryPort:    int64(nattDiscoveryPort),
+		gateways:             gateways,
 	}, nil
 }
 
@@ -129,7 +131,8 @@ func (g *gcpProvider) PrepareSubmarinerClusterEnv() error {
 	input := api.PrepareForSubmarinerInput{
 		InternalPorts: []api.PortSpec{
 			{Port: constants.SubmarinerRoutePort, Protocol: "udp"},
-			{Port: g.metricsPort, Protocol: "tcp"},
+			{Port: g.gatewayMetricsPort, Protocol: "tcp"},
+			{Port: g.globalnetMetricsPort, Protocol: "tcp"},
 		},
 	}
 	err := g.cloudPrepare.PrepareForSubmariner(input, g.reporter)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -8,8 +8,12 @@ const (
 
 	IPSecPSKSecretName = "submariner-ipsec-psk"
 
-	SubmarinerNatTPort          = 4500
-	SubmarinerNatTDiscoveryPort = 4900
-	SubmarinerRoutePort         = 4800
-	SubmarinerMetricsPort       = 8080
+	SubmarinerNatTPort           = 4500
+	SubmarinerNatTDiscoveryPort  = 4900
+	SubmarinerRoutePort          = 4800
+	SubmarinerGatewayMetricsPort = 8080
+
+	// TODO: Currently we are configuring this Port unconditionally. This is an internal port, but can be
+	// enabled only in Globalnet deployments.
+	SubmarinerGlobalnetMetricsPort = 8081
 )


### PR DESCRIPTION
Submariner Globalnet pod runs with HostNetworking enabled and the
metrics are exported on TCP/8081 port. Currently, this port is
not configured while preparing the cloud infrastructure, because
of this Globalnet metrics are not seen in OCP dashboard. This PR
fixes the issue.

Fixes: https://github.com/stolostron/submariner-addon/issues/309
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>