### PR TITLE
Use latest registration-operator

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -249,9 +249,9 @@ do
     deploy_olm "$cluster"
 done
 
-# downlaod registration-operator
+# download registration-operator
 registration_operator_dir="${work_dir}/registration-operator"
-git clone --depth 1 --branch release-2.2 https://github.com/stolostron/registration-operator.git ${registration_operator_dir}
+git clone --depth 1 https://github.com/stolostron/registration-operator.git ${registration_operator_dir}
 
 # the first cluster is hub cluster
 hub="${clusters[0]}"


### PR DESCRIPTION
Use the latest registration-operator repo to clone and deploy instead of
release-2.2. This makes sure we get latest fixes and changes, and deploy
configs are not outdated.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>