### PR TITLE
Remove 'tech-preview' from 0.12.0 version

### DIFF
--- a/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
@@ -41,5 +41,5 @@ spec:
     lighthouse-coredns: {{ .LighthouseCoreDNSImage }}
     {{- end}}
 {{- end}}
-  repository: registry.redhat.io/rhacm2-tech-preview
+  repository: registry.redhat.io/rhacm2
   version: v0.12.0

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -206,7 +206,7 @@ spec:
 EOF
 
     submrepo="quay.io/submariner"
-    submver=0.12.0-rc1
+    submver=0.12.0
     kubectl patch submarinerconfigs submariner -n ${cluster} --type "json" -p '[
 {"op":"add","path":"/spec/imagePullSpecs/submarinerImagePullSpec","value":"'${submrepo}'/submariner-gateway:'${submver}'"},
 {"op":"add","path":"/spec/imagePullSpecs/submarinerRouteAgentImagePullSpec","value":"'${submrepo}'/submariner-route-agent:'${submver}'"},


### PR DESCRIPTION
- As 0.12.0 Submariner version is going GA, 'tech-preview' should be
  removed.
- Set '0.12.0' semver in scripts/deploy.sh

Signed-off-by: Maxim Babushkin <mbabushk@redhat.com>

Fixes: https://github.com/stolostron/submariner-addon/issues/332