### PR TITLE
Revert "Create ClusterRole to allow brokers.submariner.io object"

### DIFF
--- a/deploy/config/rbac/brokers-submariner-io-cr.yaml
+++ b/deploy/config/rbac/brokers-submariner-io-cr.yaml
@@ -1,8 +1,0 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: access-to-brokers-submariner-crd
-rules:
-  - apiGroups: ["submariner.io"]
-    resources: ["brokers"]
-    verbs: ["create", "get", "update"]

--- a/deploy/config/rbac/kustomization.yaml
+++ b/deploy/config/rbac/kustomization.yaml
@@ -1,4 +1,3 @@
 resources:
   - cluster_role.yaml
   - cluster_role_binding.yaml
-  - brokers-submariner-io-cr.yaml


### PR DESCRIPTION
This reverts commit 6a37def0eaaefd0cd19d3e5d9d2bc033486aa6c7.
This PR creates the necessary ClusterRole but was causing issues
in bundle generation and was reverted on the main branch as well.
A separate PR will address this requirement.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>