### PR TITLE
Remove usage of IKEPort

### DIFF
--- a/docs/submarinerConfig.md
+++ b/docs/submarinerConfig.md
@@ -1,6 +1,6 @@
 # SubmarinerConfig
 
-SubmarinerConfig is a namespace-scoped API which can build the cluster environment automatically to meet the prerequisites for running Submariner. The User can also customize the configurations used in Submariner by SubmarinerConfig like Cable Driver, IPSec IKE ports etc.
+SubmarinerConfig is a namespace-scoped API which can build the cluster environment automatically to meet the prerequisites for running Submariner. The User can also customize the configurations used in Submariner by SubmarinerConfig like Cable Driver, IPSec NATT ports etc.
 
 The SubmarinerConfig should be created in the managed cluster namespace.
 
@@ -32,7 +32,6 @@ SubmarinerConfig can support OCP on AWS, GCP or VMware vSphere at the current st
         name: <config-name>
         namespace: <managed-cluster-namespace>
     spec:
-        IPSecIKEPort: <IPSec IKE Port>
         IPSecNATTPort: <IPSec NAT-T Port>
         credentialsSecret:
             name: <cloud-provider-credential-secret-name>

--- a/docs/submarinerConfig.md
+++ b/docs/submarinerConfig.md
@@ -1,6 +1,6 @@
 # SubmarinerConfig
 
-SubmarinerConfig is a namespace-scoped API which can build the cluster environment automatically to meet the prerequisites for running Submariner. The User can also customize the configurations used in Submariner by SubmarinerConfig like Cable Driver, IPSec NATT ports etc.
+SubmarinerConfig is a namespace-scoped API which can build the cluster environment automatically to meet the prerequisites for running Submariner. The User can also customize the configurations used in Submariner by SubmarinerConfig like Cable Driver, IPSec NAT-T ports etc.
 
 The SubmarinerConfig should be created in the managed cluster namespace.
 

--- a/pkg/hub/submarineragent/controller_test.go
+++ b/pkg/hub/submarineragent/controller_test.go
@@ -435,7 +435,6 @@ func (t *testDriver) assertSubmarinerManifestWork(work *workv1.ManifestWork) {
 
 	if t.submarinerConfig != nil {
 		Expect(submariner.Spec.CableDriver).To(Equal(t.submarinerConfig.Spec.CableDriver))
-		Expect(submariner.Spec.CeIPSecIKEPort).To(Equal(t.submarinerConfig.Spec.IPSecIKEPort))
 		Expect(submariner.Spec.CeIPSecNATTPort).To(Equal(t.submarinerConfig.Spec.IPSecNATTPort))
 		Expect(submariner.Spec.NatEnabled).To(Equal(t.submarinerConfig.Spec.NATTEnable))
 	}
@@ -507,7 +506,6 @@ func (t *testDriver) createSubmarinerConfig() {
 		},
 		Spec: configv1alpha1.SubmarinerConfigSpec{
 			CableDriver:   "vxlan",
-			IPSecIKEPort:  101,
 			IPSecNATTPort: 202,
 			NATTEnable:    true,
 			SubscriptionConfig: configv1alpha1.SubscriptionConfig{

--- a/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
@@ -11,7 +11,6 @@ spec:
   brokerK8sRemoteNamespace: {{ .BrokerNamespace }}
   cableDriver: {{ .CableDriver }}
   ceIPSecDebug: false
-  ceIPSecIKEPort: {{ .IPSecIKEPort }}
   ceIPSecNATTPort: {{ .IPSecNATTPort }}
   ceIPSecPSK: {{ .IPSecPSK }}
   clusterCIDR: ""

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo.go
@@ -56,7 +56,6 @@ var (
 type SubmarinerBrokerInfo struct {
 	NATEnabled                bool
 	LoadBalancerEnabled       bool
-	IPSecIKEPort              int
 	IPSecNATTPort             int
 	InstallationNamespace     string
 	InstallPlanApproval       string
@@ -184,10 +183,6 @@ func applySubmarinerConfig(brokerInfo *SubmarinerBrokerInfo, submarinerConfig *c
 
 	if submarinerConfig.Spec.CableDriver != "" {
 		brokerInfo.CableDriver = submarinerConfig.Spec.CableDriver
-	}
-
-	if submarinerConfig.Spec.IPSecIKEPort != 0 {
-		brokerInfo.IPSecIKEPort = submarinerConfig.Spec.IPSecIKEPort
 	}
 
 	if submarinerConfig.Spec.IPSecNATTPort != 0 {

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
@@ -173,7 +173,6 @@ var _ = Describe("Function Get", func() {
 				Expect(brokerInfo.CatalogSource).To(Equal("redhat-operators"))
 				Expect(brokerInfo.CatalogSourceNamespace).To(Equal("openshift-marketplace"))
 				Expect(brokerInfo.CatalogStartingCSV).To(BeEmpty())
-				Expect(brokerInfo.IPSecIKEPort).To(BeZero())
 				Expect(brokerInfo.IPSecNATTPort).To(Equal(4500))
 				Expect(brokerInfo.LighthouseAgentImage).To(BeEmpty())
 				Expect(brokerInfo.LighthouseCoreDNSImage).To(BeEmpty())
@@ -201,7 +200,6 @@ var _ = Describe("Function Get", func() {
 							SubmarinerRouteAgentImagePullSpec: "quay.io/submariner/submariner-route-agent:10.0.1",
 						},
 						CableDriver:        "wireguard",
-						IPSecIKEPort:       1234,
 						IPSecNATTPort:      5678,
 						NATTEnable:         true,
 						LoadBalancerEnable: true,
@@ -217,7 +215,6 @@ var _ = Describe("Function Get", func() {
 				Expect(brokerInfo.CatalogSource).To(Equal(submarinerConfig.Spec.SubscriptionConfig.Source))
 				Expect(brokerInfo.CatalogSourceNamespace).To(Equal(submarinerConfig.Spec.SubscriptionConfig.SourceNamespace))
 				Expect(brokerInfo.CatalogStartingCSV).To(Equal(submarinerConfig.Spec.SubscriptionConfig.StartingCSV))
-				Expect(brokerInfo.IPSecIKEPort).To(Equal(submarinerConfig.Spec.IPSecIKEPort))
 				Expect(brokerInfo.IPSecNATTPort).To(Equal(submarinerConfig.Spec.IPSecNATTPort))
 				Expect(brokerInfo.LighthouseAgentImage).To(Equal(submarinerConfig.Spec.ImagePullSpecs.LighthouseAgentImagePullSpec))
 				Expect(brokerInfo.LighthouseCoreDNSImage).To(Equal(submarinerConfig.Spec.ImagePullSpecs.LighthouseCoreDNSImagePullSpec))


### PR DESCRIPTION
IKEPort config is ignored when configuring cloud provider, but
still set in brokerInfo and passed on to Submariner. This causes
incosistent if someone sets a custom IKEPort.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>