### PR TITLE
Add Dependabot updates of GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 ---
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
   - package-ecosystem: gomod
     directory: "/"
     schedule:


### PR DESCRIPTION
For quicker updates and easier, more consistent maintenance.

SHA-based versions should always be used to be sure the code we pull in
can't be changed without us, for security reasons at least. Dependabot
now supports SHA-based versions for GHAs. This patch should facilitate
their continued use.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>