### PR TITLE
[release-2.5] Make dedicated g/w node default in GCP

### DIFF
--- a/pkg/cloud/gcp/gcp.go
+++ b/pkg/cloud/gcp/gcp.go
@@ -91,7 +91,7 @@ func NewGCPProvider(
 	k8sClient := k8s.NewInterface(kubeClient)
 
 	gwDeployer := cloudpreparegcp.NewOcpGatewayDeployer(cloudInfo, msDeployer, instanceType,
-		"", false, k8sClient)
+		"", true, k8sClient)
 
 	return &gcpProvider{
 		infraID:              infraID,

--- a/pkg/hub/submarineraddonagent/manifests/clusterrole.yaml
+++ b/pkg/hub/submarineraddonagent/manifests/clusterrole.yaml
@@ -15,3 +15,6 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch", "update", "patch"]
+- apiGroups: ["machine.openshift.io"]
+  resources: ["machinesets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
This is a manual cherry-pick of #300. (The automated cherry-pick failed because part of the change was included in #357.)

* Makes the dedicated gateway node as the default option in GCP.

Signed-off-by: Aswin Suryanarayanan <aswinsuryan@gmail.com>
(cherry picked from commit 4b5fdc9e75c2c0d698e676fd8dc152d3314374c4)