### PR TITLE
Revert "Support username and password authentication in RHOS"

### DIFF
--- a/pkg/cloud/rhos/rhos.go
+++ b/pkg/cloud/rhos/rhos.go
@@ -193,8 +193,6 @@ func newClient(kubeClient kubernetes.Interface, secretNamespace, secretName stri
 		TokenID:                     cloud.AuthInfo.Token,
 		ApplicationCredentialID:     cloud.AuthInfo.ApplicationCredentialID,
 		ApplicationCredentialSecret: cloud.AuthInfo.ApplicationCredentialSecret,
-		Username:                    cloud.AuthInfo.Username,
-		Password:                    cloud.AuthInfo.Password,
 	}
 
 	projectID := cloud.AuthInfo.ProjectID


### PR DESCRIPTION
This reverts commit 1df0abf02174b00b094a6940bbea73932e9bcce7 which was
merged prematurely (without an RM exception).

The fix will be re-merged following 2.5 GA, for 2.5.z.

Signed-off-by: Stephen Kitt <skitt@redhat.com>