### PR TITLE
Add Domain details for username passoword authentication

### DIFF
--- a/pkg/cloud/rhos/rhos.go
+++ b/pkg/cloud/rhos/rhos.go
@@ -196,6 +196,9 @@ func newClient(kubeClient kubernetes.Interface, secretNamespace, secretName stri
 		ApplicationCredentialSecret: cloud.AuthInfo.ApplicationCredentialSecret,
 		Username:                    cloud.AuthInfo.Username,
 		Password:                    cloud.AuthInfo.Password,
+		DomainName:                  cloud.AuthInfo.UserDomainName,
+		TenantID:                    cloud.AuthInfo.ProjectID,
+		TenantName:                  cloud.AuthInfo.ProjectName,
 	}
 
 	projectID := cloud.AuthInfo.ProjectID


### PR DESCRIPTION
To authenticate with username and password, domain details are also required. This PR adds it.

Fixes: https://github.com/stolostron/backlog/issues/22574

Signed-off-by: Aswin Suryanarayanan <aswinsuryan@gmail.com>