### PR TITLE
Remove apiextensions/v1beta1 reference

### DIFF
--- a/pkg/resource/manifest.go
+++ b/pkg/resource/manifest.go
@@ -14,7 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,7 +31,6 @@ func init() {
 	utilruntime.Must(appsv1.AddToScheme(genericScheme))
 	utilruntime.Must(corev1.AddToScheme(genericScheme))
 	utilruntime.Must(rbacv1.AddToScheme(genericScheme))
-	utilruntime.Must(apiextensionsv1beta1.AddToScheme(genericScheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(genericScheme))
 }
 


### PR DESCRIPTION
Re: https://github.com/stolostron/backlog/issues/23199, the only deprecated K8s API listed [here](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22) that is used/referenced in the code is
"_k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1_". This API is only referenced to add it to the scheme and is not actually used so remove it.

