### PR TITLE
Fix indentation in olm manifest yaml

### DIFF
--- a/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -74,7 +74,7 @@ spec:
                         default: Standard_D4s_v3
                         description: InstanceType represents the Azure Cloud Platform instance type of the gateway node that will be created on the managed cluster. The default value is `Standard_D4s_v3`.
                         type: string
-                      type: object
+                    type: object
                   gateways:
                     default: 1
                     description: Gateways represents the count of worker nodes that will be used to deploy the Submariner gateway component on the managed cluster. If the platform of managed cluster is Amazon Web Services, the submariner-addon will create the specified number of worker nodes and label them with `submariner.io/gateway` on the managed cluster, for other platforms, the submariner-addon will select the specified number of worker nodes and label them with `submariner.io/gateway` on the managed cluster. The default value is 1, if the value is greater than 1, the Submariner gateway HA will be enabled automatically.


### PR DESCRIPTION
This seems to break the downstream ACM build:

```
Error: error decoding v1 CRD: 
v1.CustomResourceDefinition.Spec: 
  v1.CustomResourceDefinitionSpec.Versions: 
    []v1.CustomResourceDefinitionVersion: 
      v1.CustomResourceDefinitionVersion.Schema:
        v1.CustomResourceValidation.OpenAPIV3Schema: 
          v1.JSONSchemaProps.Properties: 
            v1.JSONSchemaProps.Properties: 
              v1.JSONSchemaProps.Properties: 
                v1.JSONSchemaProps.Properties: readObjectStart: 
                expect { or n, but found ", 
                error found in #10 byte of ...|},"type":"object"}},|..., 
                bigger context ...|e is `Standard_D4s_v3`.","type":"string"},"type":"object"}},"gateways":{"default":1,"description":"G|...
```

These lines were added by https://github.com/stolostron/submariner-addon/pull/341 then backported to 2.5 with https://github.com/stolostron/submariner-addon/pull/358 but then reverted by https://github.com/stolostron/submariner-addon/pull/362