### PR TITLE
Only look for gateway labeled nodes

### DIFF
--- a/pkg/spoke/submarineragent/config_controller.go
+++ b/pkg/spoke/submarineragent/config_controller.go
@@ -526,7 +526,6 @@ func (c *submarinerConfigController) updateGatewayStatus(ctx context.Context, re
 	config *configv1alpha1.SubmarinerConfig,
 ) error {
 	gateways, err := c.getLabeledNodes(
-		nodeLabelSelector{workerNodeLabel, selection.Exists},
 		nodeLabelSelector{submarinerGatewayLabel, selection.Exists},
 	)
 	if err != nil {


### PR DESCRIPTION
The filter here incorrectly assumed that gateway nodes must be worker
nodes, which is not necessarily true.
Existence of `gateway` label is enough for the finding the nodes.

Partially Fixes: https://github.com/stolostron/backlog/issues/23007

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>