### PR TITLE
Allow the addon to access leases

### DIFF
--- a/deploy/config/rbac/cluster_role.yaml
+++ b/deploy/config/rbac/cluster_role.yaml
@@ -78,3 +78,6 @@ rules:
   resources: ["signers"]
   resourceNames: ["kubernetes.io/kube-apiserver-client"]
   verbs: ["approve"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "watch", "create", "update", "delete"]

--- a/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
@@ -239,6 +239,17 @@ spec:
           - signers
           verbs:
           - approve
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
         serviceAccountName: submariner-addon
       deployments:
       - name: submariner-addon


### PR DESCRIPTION
The agent role-binding already includes leases but this is apparently
no longer sufficient; allow lease management in the addon cluster-role
itself.

See https://bugzilla.redhat.com/show_bug.cgi?id=2105920

Fixes: https://github.com/stolostron/backlog/issues/24143
Signed-off-by: Stephen Kitt <skitt@redhat.com>