### PR TITLE
Downstream images don't use suffixes

### DIFF
--- a/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
@@ -44,4 +44,4 @@ spec:
     {{- end}}
 {{- end}}
   repository: registry.redhat.io/rhacm2
-  version: v0.13.0-rc1
+  version: v0.13.0


### PR DESCRIPTION
Drop the rc1 suffix, we rely on moving tags.

Signed-off-by: Stephen Kitt <skitt@redhat.com>