### PR TITLE
release-2.5: Use golang 1.18 builder container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.17-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.18-linux AS builder
 WORKDIR /go/src/github.com/stolostron/submariner-addon
 COPY . .
 ENV GO_PACKAGE github.com/stolostron/submariner-addon


### PR DESCRIPTION
Relates-to: stolostron/backlog#24214
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>