### PR TITLE
release-2.4: Use golang 1.18 builder container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.16-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.18-linux AS builder
 WORKDIR /go/src/github.com/stolostron/submariner-addon
 COPY . .
 ENV GO_PACKAGE github.com/stolostron/submariner-addon


### PR DESCRIPTION
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>