### PR TITLE
Move default provider handling to the spoke

### DIFF
--- a/pkg/cloud/cloud_suite_test.go
+++ b/pkg/cloud/cloud_suite_test.go
@@ -1,0 +1,13 @@
+package cloud_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCloud(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cloud Suite")
+}

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -1,0 +1,56 @@
+package cloud_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/library-go/pkg/operator/events"
+	configv1alpha1 "github.com/stolostron/submariner-addon/pkg/apis/submarinerconfig/v1alpha1"
+	"github.com/stolostron/submariner-addon/pkg/cloud"
+	"github.com/stolostron/submariner-addon/pkg/constants"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubeFake "k8s.io/client-go/kubernetes/fake"
+	workfake "open-cluster-management.io/api/client/work/clientset/versioned/fake"
+)
+
+var _ = Describe("ProviderFactory Get", func() {
+	var (
+		providerFactory    cloud.ProviderFactory
+		managedClusterInfo *configv1alpha1.ManagedClusterInfo
+	)
+
+	BeforeEach(func() {
+		providerFactory = cloud.NewProviderFactory(nil, kubeFake.NewSimpleClientset(), workfake.NewSimpleClientset(),
+			dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()), kubeFake.NewSimpleClientset())
+
+		managedClusterInfo = &configv1alpha1.ManagedClusterInfo{
+			ClusterName: "east",
+			Vendor:      constants.ProductOCP,
+			Platform:    "no-provider-available",
+			Region:      "test-region",
+			InfraID:     "test-infraID",
+		}
+	})
+
+	When("the ManagedClusterInfo Platform has no provider implementation", func() {
+		It("should return false", func() {
+			provider, found, err := providerFactory.Get(managedClusterInfo, &configv1alpha1.SubmarinerConfig{},
+				events.NewLoggingEventRecorder("test"))
+			Expect(err).To(Succeed())
+			Expect(found).To(BeFalse())
+			Expect(provider).To(BeNil())
+		})
+	})
+
+	When("the ManagedClusterInfo Vendor is not supported", func() {
+		BeforeEach(func() {
+			managedClusterInfo.Vendor = "not-supported"
+		})
+
+		It("should return an error", func() {
+			_, _, err := providerFactory.Get(managedClusterInfo, &configv1alpha1.SubmarinerConfig{},
+				events.NewLoggingEventRecorder("test"))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/pkg/cloud/fake/cloud.go
+++ b/pkg/cloud/fake/cloud.go
@@ -88,12 +88,13 @@ func (m *MockProviderFactory) EXPECT() *MockProviderFactoryMockRecorder {
 }
 
 // Get mocks base method.
-func (m *MockProviderFactory) Get(managedClusterInfo v1alpha1.ManagedClusterInfo, config *v1alpha1.SubmarinerConfig, eventsRecorder events.Recorder) (cloud.Provider, error) {
+func (m *MockProviderFactory) Get(managedClusterInfo *v1alpha1.ManagedClusterInfo, config *v1alpha1.SubmarinerConfig, eventsRecorder events.Recorder) (cloud.Provider, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", managedClusterInfo, config, eventsRecorder)
 	ret0, _ := ret[0].(cloud.Provider)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Get indicates an expected call of Get.

--- a/pkg/hub/submarineragent/controller.go
+++ b/pkg/hub/submarineragent/controller.go
@@ -375,7 +375,7 @@ func (c *submarinerAgentController) syncSubmarinerConfig(ctx context.Context,
 	errs := []error{}
 	var condition *metav1.Condition
 	if !isSpokePrepared(managedClusterInfo.Platform) {
-		cloudProvider, preparedErr := c.cloudProviderFactory.Get(managedClusterInfo, config, c.eventRecorder)
+		cloudProvider, _, preparedErr := c.cloudProviderFactory.Get(&managedClusterInfo, config, c.eventRecorder)
 		if preparedErr == nil {
 			preparedErr = cloudProvider.PrepareSubmarinerClusterEnv()
 		}
@@ -627,7 +627,7 @@ func (c *submarinerAgentController) removeClusterRBACFiles(ctx context.Context, 
 }
 
 func (c *submarinerAgentController) cleanUpSubmarinerClusterEnv(config *configv1alpha1.SubmarinerConfig) error {
-	cloudProvider, err := c.cloudProviderFactory.Get(config.Status.ManagedClusterInfo, config, c.eventRecorder)
+	cloudProvider, _, err := c.cloudProviderFactory.Get(&config.Status.ManagedClusterInfo, config, c.eventRecorder)
 	if err != nil {
 		// TODO handle the error gracefully in the future
 		c.eventRecorder.Warningf("CleanUpSubmarinerClusterEnvFailed", "failed to get cloud provider: %v", err)
@@ -792,9 +792,5 @@ func (c *submarinerAgentController) createGNConfigMapIfNecessary(brokerNamespace
 }
 
 func isSpokePrepared(cloudName string) bool {
-	if cloudName == "GCP" || cloudName == "OpenStack" || cloudName == "Azure" {
-		return true
-	}
-
-	return false
+	return cloudName != "AWS"
 }

--- a/pkg/hub/submarineragent/controller_test.go
+++ b/pkg/hub/submarineragent/controller_test.go
@@ -332,7 +332,7 @@ func newTestDriver() *testDriver {
 		addOnInformerFactory := addoninformers.NewSharedInformerFactory(t.addOnClient, 0)
 
 		providerFactory := cloudFake.NewMockProviderFactory(t.mockCtrl)
-		providerFactory.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(t.cloudProvider, nil).AnyTimes()
+		providerFactory.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(t.cloudProvider, true, nil).AnyTimes()
 
 		controller := submarineragent.NewSubmarinerAgentController(t.kubeClient, t.dynamicClient, t.clusterClient,
 			t.manifestWorkClient, t.configClient, t.addOnClient,


### PR DESCRIPTION
...specifically the case where there's no cloud provider implementation for a platform. We still want to set the status
condition indicating the environment was prepared. Previously this was done on the hub but it should be done on the spoke as only AWS is handled on the hub (and the intention is to move this to the spoke as well).

The `cloud.Providerfactory` was modified to also return a boolean indicating whether or not a `Provider` exists.
