### PR TITLE
Check OCP version for OVNK

### DIFF
--- a/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -206,6 +206,9 @@ spec:
                   infraId:
                     description: InfraId represents the infrastructure id of the managed cluster.
                     type: string
+                  networkType:
+                    description: NetworkType represents the network type (cni) of the managed cluster.
+                    type: string
                   platform:
                     description: Platform represents the cloud provider of the managed cluster.
                     type: string
@@ -214,6 +217,9 @@ spec:
                     type: string
                   vendor:
                     description: Vendor represents the kubernetes vendor of the managed cluster.
+                    type: string
+                  vendorVersion:
+                    description: VendorVersion represents the k8s vendor version of the managed cluster.
                     type: string
                 type: object
             type: object

--- a/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -204,6 +204,9 @@ spec:
                   infraId:
                     description: InfraId represents the infrastructure id of the managed cluster.
                     type: string
+                  networkType:
+                    description: NetworkType represents the network type (cni) of the managed cluster.
+                    type: string
                   platform:
                     description: Platform represents the cloud provider of the managed cluster.
                     type: string
@@ -212,6 +215,9 @@ spec:
                     type: string
                   vendor:
                     description: Vendor represents the kubernetes vendor of the managed cluster.
+                    type: string
+                  vendorVersion:
+                    description: VendorVersion represents the k8s vendor version of the managed cluster.
                     type: string
                 type: object
             type: object

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.11
+	github.com/coreos/go-semver v0.3.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/golang/mock v1.6.0
 	github.com/gophercloud/gophercloud v0.25.0
@@ -66,7 +67,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect

--- a/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
+++ b/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
@@ -206,6 +206,9 @@ spec:
                   infraId:
                     description: InfraId represents the infrastructure id of the managed cluster.
                     type: string
+                  networkType:
+                    description: NetworkType represents the network type (cni) of the managed cluster.
+                    type: string
                   platform:
                     description: Platform represents the cloud provider of the managed cluster.
                     type: string
@@ -214,6 +217,9 @@ spec:
                     type: string
                   vendor:
                     description: Vendor represents the kubernetes vendor of the managed cluster.
+                    type: string
+                  vendorVersion:
+                    description: VendorVersion represents the k8s vendor version of the managed cluster.
                     type: string
                 type: object
             type: object

--- a/pkg/apis/submarinerconfig/v1alpha1/types.go
+++ b/pkg/apis/submarinerconfig/v1alpha1/types.go
@@ -238,6 +238,12 @@ type ManagedClusterInfo struct {
 	// InfraId represents the infrastructure id of the managed cluster.
 	// +optional
 	InfraID string `json:"infraId,omitempty"`
+	// VendorVersion represents k8s vendor version of the managed cluster.
+	// +optional
+	VendorVersion string `json:"vendorVersion,omitempty"`
+	// NetworkType represents the network type (cni) of the managed cluster.
+	// +optional
+	NetworkType string `json:"networkType,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/submarinerconfig/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/pkg/apis/submarinerconfig/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -48,11 +48,13 @@ func (GatewayConfig) SwaggerDoc() map[string]string {
 }
 
 var map_ManagedClusterInfo = map[string]string{
-	"clusterName": "ClusterName represents the name of the managed cluster.",
-	"vendor":      "Vendor represents the kubernetes vendor of the managed cluster.",
-	"platform":    "Platform represents the cloud provider of the managed cluster.",
-	"region":      "Region represents the cloud region of the managed cluster.",
-	"infraId":     "InfraId represents the infrastructure id of the managed cluster.",
+	"clusterName":   "ClusterName represents the name of the managed cluster.",
+	"vendor":        "Vendor represents the kubernetes vendor of the managed cluster.",
+	"platform":      "Platform represents the cloud provider of the managed cluster.",
+	"region":        "Region represents the cloud region of the managed cluster.",
+	"infraId":       "InfraId represents the infrastructure id of the managed cluster.",
+	"vendorVersion": "VendorVersion represents k8s vendor version of the managed cluster.",
+	"networkType":   "NetworkType represents the network type (cni) of the managed cluster.",
 }
 
 func (ManagedClusterInfo) SwaggerDoc() map[string]string {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -4,7 +4,8 @@ const (
 	SubmarinerAddOnName  = "submariner"
 	SubmarinerConfigName = "submariner"
 
-	ProductOCP = "OpenShift"
+	ProductOCP        = "OpenShift"
+	OCPVersionForOVNK = "4.11.0-rc"
 
 	IPSecPSKSecretName = "submariner-ipsec-psk"
 

--- a/pkg/hub/submarineraddonagent/manifests/clusterrole.yaml
+++ b/pkg/hub/submarineraddonagent/manifests/clusterrole.yaml
@@ -19,5 +19,5 @@ rules:
   resources: ["machinesets"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: ["config.openshift.io"]
-  resources: ["apiservers", "infrastructures", "infrastructures/status"]
+  resources: ["apiservers", "networks", "infrastructures", "infrastructures/status"]
   verbs: ["get"]

--- a/pkg/hub/submarineragent/controller.go
+++ b/pkg/hub/submarineragent/controller.go
@@ -730,6 +730,10 @@ func getManagedClusterInfo(managedCluster *clusterv1.ManagedCluster) configv1alp
 				clusterInfo.InfraID = fmt.Sprintf("%v", infraInfo["infraName"])
 			}
 		}
+
+		if claim.Name == "version.openshift.io" {
+			clusterInfo.VendorVersion = claim.Value
+		}
 	}
 
 	return clusterInfo

--- a/pkg/spoke/agent.go
+++ b/pkg/spoke/agent.go
@@ -139,6 +139,8 @@ func (o *AgentOptions) RunAgent(ctx context.Context, controllerContext *controll
 		ClusterName:          o.ClusterName,
 		KubeClient:           spokeKubeClient,
 		ConfigClient:         configHubKubeClient,
+		AddOnClient:          addOnHubKubeClient,
+		DynamicClient:        spokeDynamicClient,
 		NodeInformer:         spokeKubeInformers.Core().V1().Nodes(),
 		AddOnInformer:        addOnInformers.Addon().V1alpha1().ManagedClusterAddOns(),
 		ConfigInformer:       configInformers.Submarineraddon().V1alpha1().SubmarinerConfigs(),

--- a/pkg/spoke/submarineragent/config_controller_test.go
+++ b/pkg/spoke/submarineragent/config_controller_test.go
@@ -22,6 +22,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	kubeInformers "k8s.io/client-go/informers"
 	kubeFake "k8s.io/client-go/kubernetes/fake"
 	clientTesting "k8s.io/client-go/testing"
@@ -557,6 +559,7 @@ type configControllerTestDriver struct {
 	stop          context.CancelFunc
 	kubeClient    *kubeFake.Clientset
 	configClient  *configFake.Clientset
+	dynamicClient *dynamicfake.FakeDynamicClient
 	cloudProvider *cloudFake.MockProvider
 	mockCtrl      *gomock.Controller
 }
@@ -580,6 +583,7 @@ func newConfigControllerTestDriver() *configControllerTestDriver {
 
 		t.kubeClient = kubeFake.NewSimpleClientset()
 		t.configClient = configFake.NewSimpleClientset()
+		t.dynamicClient = dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
 
 		t.managedClusterAddOnTestBase.init()
 
@@ -624,6 +628,8 @@ func newConfigControllerTestDriver() *configControllerTestDriver {
 			ClusterName:          clusterName,
 			KubeClient:           t.kubeClient,
 			ConfigClient:         t.configClient,
+			DynamicClient:        t.dynamicClient,
+			AddOnClient:          t.addOnClient,
 			NodeInformer:         kubeInformerFactory.Core().V1().Nodes(),
 			AddOnInformer:        addOnInformerFactory.Addon().V1alpha1().ManagedClusterAddOns(),
 			ConfigInformer:       configInformerFactory.Submarineraddon().V1alpha1().SubmarinerConfigs(),


### PR DESCRIPTION
OVNK requires OCP 4.11+ Check OCP version and set appropriate
status and error if unsupported version.

Note: We set status in Gateways node label coz it is used in
UI.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>