### PR TITLE
Create the addon SA before the deployment

### DIFF
--- a/pkg/hub/submarineraddonagent/agent.go
+++ b/pkg/hub/submarineraddonagent/agent.go
@@ -52,12 +52,12 @@ const (
 const agentInstallationNamespaceFile = "manifests/namespace.yaml"
 
 var agentDeploymentFiles = []string{
+	"manifests/serviceaccount.yaml",
 	"manifests/clusterrole.yaml",
 	"manifests/clusterrolebinding.yaml",
-	"manifests/deployment.yaml",
 	"manifests/role.yaml",
 	"manifests/rolebinding.yaml",
-	"manifests/serviceaccount.yaml",
+	"manifests/deployment.yaml",
 }
 
 var agentHubPermissionFiles = []string{


### PR DESCRIPTION
The agent uses a ManifestWork to deploy the agent on the hub; this
ManifestWork is charged with creating the roles, role bindings,
service account, and deployment for the addon. In some cases, the
deployment fails because the service account hasn't been created by
the time the pod replicaset is instantiated.

This reorders the ManifestWork entries so that the SA comes first,
followed by the roles and bindings, and the deployment comes last.
This should ensure that the SA is created before any resource which
needs it.

Signed-off-by: Stephen Kitt <skitt@redhat.com>