### PR TITLE
Fix Sonar src/test paths

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,10 +1,10 @@
 sonar.projectKey=open-cluster-management_submariner-addon
 sonar.projectName=submariner-addon
 sonar.sources=.
-sonar.exclusions=**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**,**/test/**,**/cmd/**,**/pkg/apis/**
+sonar.exclusions=deploy/**,pkg/client/**,tools/**,vendor/**,**/cmd/**,**/fake/**,**/v1alpha1/**,test/**,**/*_test.go
 sonar.tests=.
-sonar.test.inclusions=**/*_test.go
-sonar.test.exclusions=**/*_generated*.go,**/*_generated/**,**/vendor/**
+sonar.test.inclusions=test/**,**/*_test.go
+sonar.test.exclusions=deploy/**,pkg/client/**,tools/**,vendor/**,**/cmd/**,**/fake/**,**/v1alpha1/**
 sonar.go.tests.reportPaths=report.json
 sonar.go.coverage.reportPaths=coverage.out
 sonar.externalIssuesReportPaths=gosec.json


### PR DESCRIPTION
These were defaults that didn't match reality and resulted in bad scores
and useless reporting. Update Sonar's source/test include/exclude rules
to be correct for this repo.

Relates-to: stolostron/backlog#22706
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>