### PR TITLE
Ignore false gosec G101 hard-coded credential

### DIFF
--- a/pkg/cloud/aws/aws.go
+++ b/pkg/cloud/aws/aws.go
@@ -20,8 +20,9 @@ import (
 const (
 	defaultInstanceType  = "m5n.large"
 	accessKeyIDSecretKey = "aws_access_key_id"
-	accessKeySecretKey   = "aws_secret_access_key"
-	workName             = "aws-submariner-gateway-machineset"
+	//#nosec G101 -- This is the name of a key that will store a secret, but not a default secret
+	accessKeySecretKey = "aws_secret_access_key"
+	workName           = "aws-submariner-gateway-machineset"
 )
 
 type awsProvider struct {


### PR DESCRIPTION
The gosec report generated by ACM CI and imported to Sonar flags this.
I'm not sure why gosec doesnt't flag this when run through
golangci-lint.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>