### PR TITLE
Update LB status in Submariner CR based on Config

### DIFF
--- a/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
@@ -15,6 +15,7 @@ spec:
   ceIPSecPSK: {{ .IPSecPSK }}
   clusterCIDR: ""
   globalCIDR: "{{ .GlobalCIDR }}"
+  loadBalancerEnabled: "{{ .LoadBalancerEnabled }}"
   clusterID: {{ .ClusterName }}
   colorCodes: blue
   debug: false


### PR DESCRIPTION
This PR updates the Loadbalancer status in the submariner CR
object based on the value in SubmarinerConfig object. This
will allow us to enable loadbalancer support by appropriately
setting the value in the SubmarinerConfig object.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>