### PR TITLE
Trigger initial submariner-addon build targeting ACM 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# submariner-addon
+# submariner-addon 
 
 An integration between ACM and [Submariner](https://submariner.io/). Submariner enables direct networking between Pods and Services in different Kubernetes clusters.
 


### PR DESCRIPTION
## Summary of Changes

This change is a no-op commit to the submariner-addon repository to trigger a build and fast-forward to the release-2.7 branch to verify updated build and fast-forward configurations for https://github.com/stolostron/backlog/issues/24879.  