### PR TITLE
Allow the broker to watch secrets

### DIFF
--- a/pkg/hub/submarineraddonagent/manifests/hub_role.yaml
+++ b/pkg/hub/submarineraddonagent/manifests/hub_role.yaml
@@ -26,4 +26,4 @@ rules:
   verbs: ["patch", "update"]
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "watch"]


### PR DESCRIPTION
This is required for the secret syncer.

Signed-off-by: Stephen Kitt <skitt@redhat.com>