### PR TITLE
Configure dependabot on the release branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,31 @@ updates:
       - dependency-name: github.com/operator-framework/*
       - dependency-name: k8s.io/*
       - dependency-name: sigs.k8s.io/*
+  - package-ecosystem: gomod
+    target-branch: "release-2.5"
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    ignore:
+      # K8s and operator SDK, we need to handle these manually
+      - dependency-name: github.com/operator-framework/*
+      - dependency-name: k8s.io/*
+      - dependency-name: sigs.k8s.io/*
+      # 2.5 tracks Submariner 0.12
+      - dependency-name: github.com/submariner-io/*
+        ignore: ">= 0.13.0"
+  - package-ecosystem: gomod
+    target-branch: "release-2.6"
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    ignore:
+      # K8s and operator SDK, we need to handle these manually
+      - dependency-name: github.com/operator-framework/*
+      - dependency-name: k8s.io/*
+      - dependency-name: sigs.k8s.io/*
+      # 2.6 tracks Submariner 0.13
+      - dependency-name: github.com/submariner-io/*
+        ignore: ">= 0.14.0"


### PR DESCRIPTION
This should cause dependabot to open PRs when new point-releases of Submariner become available.

Signed-off-by: Stephen Kitt <skitt@redhat.com>