### PR TITLE
Verify regenerating CRDs doesn't result in changes

### DIFF
--- a/hack/verify-crds.sh
+++ b/hack/verify-crds.sh
@@ -21,3 +21,15 @@ done
 if [ "$FAILS" = true ] ; then
     exit 1
 fi
+
+# Verify regenerating CRDs doesn't result in changes
+if [ ! git diff --exit-code deploy/config/crds pkg/apis ] ; then
+    echo "There are already changes to the CRDs, can't verify regeneration doesn't cause changes."
+    exit 1
+fi
+make update-crds
+if [ ! git diff --exit-code deploy/config/crds pkg/apis ] ; then
+    echo "Regenerating CRDs (make update-crds) resulted in changes."
+    echo "Commit the CRD updates along with the changes that cause them."
+    exit 1
+fi


### PR DESCRIPTION
Ensure changes that cause CRD updates are commited with the CRD updates.

Relates-to: stolostron/submariner-addon#395
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>