### PR TITLE
Verify regenerating CSV doesn't result in changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ verify-scripts:
 	bash -x hack/verify-deepcopy.sh
 	bash -x hack/verify-swagger-docs.sh
 	bash -x hack/verify-crds.sh
+	bash -x hack/verify-csv.sh
 	bash -x hack/verify-codegen.sh
 .PHONY: verify-scripts
 

--- a/hack/verify-csv.sh
+++ b/hack/verify-csv.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Verify regenerating OLM CSV doesn't result in changes
+if [ ! git diff --exit-code deploy/olm-catalog ] ; then
+    echo "There are already changes to the CSV, can't verify regeneration doesn't cause changes."
+    exit 1
+fi
+make update-csv
+if [ ! git diff --exit-code deploy/olm-catalog ] ; then
+    echo "Regenerating CSV (make update-csv ) resulted in changes."
+    echo "Commit the CSV updates along with the changes that cause them."
+    exit 1
+fi


### PR DESCRIPTION
Ensure changes that cause CSV updates are commited with the CSV updates.

Relates-to: #395
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>