### PR TITLE
Use boolean for LoadBalancerEnabled

### DIFF
--- a/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
@@ -15,7 +15,7 @@ spec:
   ceIPSecPSK: {{ .IPSecPSK }}
   clusterCIDR: ""
   globalCIDR: "{{ .GlobalCIDR }}"
-  loadBalancerEnabled: "{{ .LoadBalancerEnabled }}"
+  loadBalancerEnabled: {{ .LoadBalancerEnabled }}
   clusterID: {{ .ClusterName }}
   colorCodes: blue
   debug: false


### PR DESCRIPTION
Submariner CR defines LoadBalancerEnabled flag as bool but the manifest to create Submariner CR uses a string. This results in error when creating submariner CR on managedcluster and Submariner isn't deployed.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>