### PR TITLE
Update K8s version to v1.23.4

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source scripts/clusters.sh
-k8s_version="v1.20.2"
+k8s_version="v1.23.4"
 
 if [ "$1"x = "cleanup"x ]; then
     for cluster in "${clusters[@]}"; do


### PR DESCRIPTION
The kindnet CNI pod was trying to access a sysfs entry which was not present in the v1.20.2 nodeImage used currently. Because of this, the KIND deployment was failing. This PR updates the k8s_version which inturn updates the nodeImage version to v1.23.4 to fix the issue.

Fixes: https://github.com/stolostron/submariner-addon/issues/516
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>