### PR TITLE
Add metric proxy and nettest image overrides

### DIFF
--- a/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -123,6 +123,12 @@ spec:
                   submarinerRouteAgentImagePullSpec:
                     description: SubmarinerRouteAgentImagePullSpec represents the desired image of the submariner route agent.
                     type: string
+                  metricsProxyImagePullSpec:
+                    description: MetricsProxyImagePullSpec represents the desired image of the metrics proxy.
+                    type: string
+                  nettestImagePullSpec:
+                    description: NettestImagePullSpec represents the desired image of nettest.
+                    type: string
                 type: object
               loadBalancerEnable:
                 default: false

--- a/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -109,6 +109,12 @@ spec:
                   lighthouseCoreDNSImagePullSpec:
                     description: LighthouseCoreDNSImagePullSpec represents the desired image of lighthouse coredns.
                     type: string
+                  metricsProxyImagePullSpec:
+                    description: MetricsProxyImagePullSpec represents the desired image of the metrics proxy.
+                    type: string
+                  nettestImagePullSpec:
+                    description: NettestImagePullSpec represents the desired image of nettest.
+                    type: string
                   submarinerGlobalnetImagePullSpec:
                     description: SubmarinerGlobalnetImagePullSpec represents the desired image of the submariner globalnet.
                     type: string

--- a/docs/submarinerConfig.md
+++ b/docs/submarinerConfig.md
@@ -127,5 +127,7 @@ SubmarinerConfig can support OCP on AWS, GCP or VMware vSphere at the current st
           lighthouseAgentImagePullSpec: <lighthouse-agent-image-pull-spec>
           lighthouseCoreDNSImagePullSpec: <lighthouse-coredns-image-pull-spec>
           submarinerRouteAgentImagePullSpec: <submariner-route-image-pull-spec>
+          metricsProxyImagePullSpec: <metrics-proxy-image-pull-spec>
+          nettestImagePullSpec: <nettest-image-pull-spec>
         ...
     ```

--- a/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
+++ b/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
@@ -123,6 +123,12 @@ spec:
                   submarinerRouteAgentImagePullSpec:
                     description: SubmarinerRouteAgentImagePullSpec represents the desired image of the submariner route agent.
                     type: string
+                  metricsProxyImagePullSpec:
+                    description: MetricsProxyImagePullSpec represents the desired image of the metrics proxy.
+                    type: string
+                  nettestImagePullSpec:
+                    description: NettestImagePullSpec represents the desired image of nettest.
+                    type: string
                 type: object
               loadBalancerEnable:
                 default: false

--- a/pkg/apis/submarinerconfig/v1alpha1/types.go
+++ b/pkg/apis/submarinerconfig/v1alpha1/types.go
@@ -136,6 +136,14 @@ type SubmarinerImagePullSpecs struct {
 	// SubmarinerNetworkPluginSyncerImagePullSpec represents the desired image of the submariner networkplugin syncer.
 	// +optional
 	SubmarinerNetworkPluginSyncerImagePullSpec string `json:"submarinerNetworkPluginSyncerImagePullSpec,omitempty"`
+
+	// MetricsProxyImagePullSpec represents the desired image of the metrics proxy.
+	// +optional
+	MetricsProxyImagePullSpec string `json:"metricsProxyImagePullSpec,omitempty"`
+
+	// NettestImagePullSpec represents the desired image of nettest.
+	// +optional
+	NettestImagePullSpec string `json:"nettestImagePullSpec,omitempty"`
 }
 
 type GatewayConfig struct {

--- a/pkg/apis/submarinerconfig/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/pkg/apis/submarinerconfig/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -125,6 +125,8 @@ var map_SubmarinerImagePullSpecs = map[string]string{
 	"submarinerRouteAgentImagePullSpec":          "SubmarinerRouteAgentImagePullSpec represents the desired image of the submariner route agent.",
 	"submarinerGlobalnetImagePullSpec":           "SubmarinerGlobalnetImagePullSpec represents the desired image of the submariner globalnet.",
 	"submarinerNetworkPluginSyncerImagePullSpec": "SubmarinerNetworkPluginSyncerImagePullSpec represents the desired image of the submariner networkplugin syncer.",
+	"metricsProxyImagePullSpec":                  "MetricsProxyImagePullSpec represents the desired image of the metrics proxy.",
+	"nettestImagePullSpec":                       "NettestImagePullSpec represents the desired image of nettest.",
 }
 
 func (SubmarinerImagePullSpecs) SwaggerDoc() map[string]string {

--- a/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
@@ -43,6 +43,12 @@ spec:
     {{- if .LighthouseCoreDNSImage }}
     lighthouse-coredns: {{ .LighthouseCoreDNSImage }}
     {{- end}}
+    {{- if .MetricsProxyImage }}
+    submariner-metrics-proxy: {{ .MetricsProxyImage }}
+    {{- end}}
+    {{- if .NettestImage }}
+    submariner-nettest: {{ .NettestImage }}
+    {{- end}}
 {{- end}}
   repository: registry.redhat.io/rhacm2
   version: v0.13.1

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo.go
@@ -81,6 +81,8 @@ type SubmarinerBrokerInfo struct {
 	SubmarinerNetworkPluginSyncerImage string
 	LighthouseAgentImage               string
 	LighthouseCoreDNSImage             string
+	MetricsProxyImage                  string
+	NettestImage                       string
 }
 
 // Get retrieves submariner broker information consolidated with hub information.
@@ -239,6 +241,14 @@ func applySubmarinerImageConfig(brokerInfo *SubmarinerBrokerInfo, submarinerConf
 
 	if submarinerConfig.Spec.ImagePullSpecs.SubmarinerNetworkPluginSyncerImagePullSpec != "" {
 		brokerInfo.SubmarinerNetworkPluginSyncerImage = submarinerConfig.Spec.ImagePullSpecs.SubmarinerNetworkPluginSyncerImagePullSpec
+	}
+
+	if submarinerConfig.Spec.ImagePullSpecs.MetricsProxyImagePullSpec != "" {
+		brokerInfo.MetricsProxyImage = submarinerConfig.Spec.ImagePullSpecs.MetricsProxyImagePullSpec
+	}
+
+	if submarinerConfig.Spec.ImagePullSpecs.NettestImagePullSpec != "" {
+		brokerInfo.NettestImage = submarinerConfig.Spec.ImagePullSpecs.NettestImagePullSpec
 	}
 }
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -214,6 +214,8 @@ EOF
 {"op":"add","path":"/spec/imagePullSpecs/lighthouseCoreDNSImagePullSpec","value":"'${submrepo}'/lighthouse-coredns:'${submver}'"},
 {"op":"add","path":"/spec/imagePullSpecs/submarinerGlobalnetImagePullSpec","value":"'${submrepo}'/submariner-globalnet:'${submver}'"},
 {"op":"add","path":"/spec/imagePullSpecs/submarinerNetworkPluginSyncerImagePullSpec","value":"'${submrepo}'/submariner-networkplugin-syncer:'${submver}'"},
+{"op":"add","path":"/spec/imagePullSpecs/metricsProxyImagePullSpec","value":"'${submrepo}'/nettest:'${submver}'"},
+{"op":"add","path":"/spec/imagePullSpecs/nettestImagePullSpec","value":"'${submrepo}'/nettest:'${submver}'"},
 {"op":"add","path":"/spec/NATTEnable","value":false}]'
 
 }


### PR DESCRIPTION
Add support to override the metrics proxy and the nettest images in the `SubmarinerConfig`.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>