### PR TITLE
Bump build-machinery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.22.1
 	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68
-	github.com/openshift/build-machinery-go v0.0.0-20220121085309-f94edc2d6874
+	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc
 	github.com/operator-framework/api v0.5.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -599,8 +599,8 @@ github.com/onsi/gomega v1.22.1/go.mod h1:x6n7VNe4hw0vkyYUM4mjIXx3JbLiPaBPNgB7PRQ
 github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68 h1:G4GBjFvaGlHc1dMFfJY8Z0LhMa0leRG75DvQ33PAgdY=
 github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68/go.mod h1:LEnw1IVscIxyDnltE3Wi7bQb/QzIM8BfPNKoGA1Qlxw=
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
-github.com/openshift/build-machinery-go v0.0.0-20220121085309-f94edc2d6874 h1:zNOsvx6zHh4qZxD/YEubNTxZ61Ko2JbDVvhnlRN6k30=
-github.com/openshift/build-machinery-go v0.0.0-20220121085309-f94edc2d6874/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
+github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR4ah7FfaPR1WePizm0jlrsbmPu91xQZnAsVVreQV1k=
+github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a h1:ylsEgoC8Dlg4A0C1TLH0A4x/TZao7k1YveLwROhRUdk=
 github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a/go.mod h1:eDO5QeVi2IiXmDwB0e2z1DpAznWroZKe978pzZwFBzg=
 github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc h1:j+upvKc1uLzuL+q/JXie8+IMohOooTCaEC9w+4d1Ztk=

--- a/vendor/github.com/openshift/build-machinery-go/Makefile
+++ b/vendor/github.com/openshift/build-machinery-go/Makefile
@@ -7,7 +7,6 @@ examples :=$(wildcard ./make/examples/*/Makefile.test)
 
 # $1 - makefile name relative to ./make/ folder
 # $2 - target
-# $3 - output folder
 # We need to change dir to the final makefile directory or relative paths won't match.
 # Dynamic values are replaced with "<redacted_for_diff>" so we can do diff against checkout versions.
 # Avoid comparing local paths by stripping the prefix.
@@ -16,39 +15,36 @@ examples :=$(wildcard ./make/examples/*/Makefile.test)
 # Ignore old cp errors on centos7
 # Ignore different make output with `-k` option
 define update-makefile-log
-mkdir -p "$(3)"
-set -o pipefail; $(MAKE) -j 1 -C "$(dir $(1))" -f "$(notdir $(1))" --no-print-directory --warn-undefined-variables $(2) 2>&1 | \
-   sed 's/\.\(buildDate\|versionFromGit\|commitFromGit\|gitTreeState\)="[^"]*" /.\1="<redacted_for_diff>" /g' | \
+set -o pipefail; $(MAKE) -j 1 -C "$(dir $(1))" -f "$(notdir $(1))" --no-print-directory --warn-undefined-variables $(2) > "$(1)$(subst ..,.,.$(2).log.raw)" 2>&1 || (cat "$(1)$(subst ..,.,.$(2).log.raw)" && exit 1)
+sed 's/\.\(buildDate\|versionFromGit\|commitFromGit\|gitTreeState\)="[^"]*" /.\1="<redacted_for_diff>" /g' "$(1)$(subst ..,.,.$(2).log.raw)" | \
    sed -E 's~/[^ ]*/(github.com/openshift/build-machinery-go/[^ ]*)~/\1~g' | \
    sed '/\/tmp\/tmp./d' | \
    sed '/git checkout -b/d' | \
    sed -E 's~^[<> ]*((\+\+\+|\-\-\-) \./(testing/)?manifests/.*.yaml).*~\1~' | \
    sed -E 's/^(make\[2\]: \*\*\* \[).*: (.*\] Error 1)/\1\2/' | \
    grep -v 'are the same file' | \
-   grep -E -v -e '^make\[2\]: Target `.*'"'"' not remade because of errors\.$$' | \
-   tee "$(3)"/"$(notdir $(1))"$(subst ..,.,.$(2).log)
+   grep -E -v -e '^make\[2\]: Target `.*'"'"' not remade because of errors\.$$' \
+   > "$(1)$(subst ..,.,.$(2).log)"
 
 endef
 
 
 # $1 - makefile name relative to ./make/ folder
 # $2 - target
-# $3 - output folder
 define check-makefile-log
-$(call update-makefile-log,$(1),$(2),$(3))
-diff -N "$(1)$(subst ..,.,.$(2).log)" "$(3)/$(notdir $(1))$(subst ..,.,.$(2).log)"
+$(call update-makefile-log,$(1),$(2))
+git diff --exit-code
 
 endef
 
 update-makefiles:
-	$(foreach f,$(makefiles),$(call check-makefile-log,$(f),help,$(dir $(f))))
-	$(foreach f,$(examples),$(call check-makefile-log,$(f),,$(dir $(f))))
+	$(foreach f,$(makefiles),$(call check-makefile-log,$(f),help))
+	$(foreach f,$(examples),$(call check-makefile-log,$(f),))
 .PHONY: update-makefiles
 
-verify-makefiles: tmp_dir:=$(shell mktemp -d)
 verify-makefiles:
-	$(foreach f,$(makefiles),$(call check-makefile-log,$(f),help,$(tmp_dir)/$(dir $(f))))
-	$(foreach f,$(examples),$(call check-makefile-log,$(f),,$(tmp_dir)/$(dir $(f))))
+	$(foreach f,$(makefiles),$(call check-makefile-log,$(f),help))
+	$(foreach f,$(examples),$(call check-makefile-log,$(f),))
 .PHONY: verify-makefiles
 
 verify: verify-makefiles

--- a/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
@@ -50,7 +50,7 @@ GO_TEST_FLAGS ?=-race
 
 GO_LD_EXTRAFLAGS ?=
 
-SOURCE_GIT_TAG ?=$(shell git describe --long --tags --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown')
+SOURCE_GIT_TAG ?=$(shell git describe --long --tags --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown-$(SOURCE_GIT_COMMIT)')
 SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)
 SOURCE_GIT_TREE_STATE ?=$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty')
 

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/controller-gen.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/controller-gen.mk
@@ -8,7 +8,7 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 # reporting `(devel)`. To build for a given platform:
 # 	GOOS=xxx GOARCH=yyy go install sigs.k8s.io/controller-tools/cmd/controller-gen@$version
 # e.g.
-# 	GOOS=darwin GOARCH=amd64 go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0
+# 	GOOS=darwin GOARCH=amd64 go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2
 #
 # If GOOS and GOARCH match your current go env, this will install the binary at
 # 	$(go env GOPATH)/bin/controller-gen
@@ -16,7 +16,7 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 # 	$(go env GOPATH)/bin/${GOOS}_${GOARCH}/conroller-gen
 # e.g.
 # 	/home/efried/.gvm/pkgsets/go1.16/global/bin/darwin_amd64/controller-gen
-CONTROLLER_GEN_VERSION ?=v0.7.0
+CONTROLLER_GEN_VERSION ?=v0.9.2
 CONTROLLER_GEN ?=$(PERMANENT_TMP_GOPATH)/bin/controller-gen-$(CONTROLLER_GEN_VERSION)
 ifneq "" "$(wildcard $(CONTROLLER_GEN))"
 _controller_gen_installed_version = $(shell $(CONTROLLER_GEN) --version | awk '{print $$2}')

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/crd-schema-gen.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/crd-schema-gen.mk
@@ -14,6 +14,12 @@ define patch-crd-yq
 endef
 
 # $1 - crd file
+define format-yaml
+	cat '$(1)' | $(YQ) read - > t.yaml
+	mv t.yaml '$(1)'
+endef
+
+# $1 - crd file
 # $2 - patch file
 define patch-crd-yaml-patch
 	$(YAML_PATCH) -o '$(2)' < '$(1)' > '$(1).patched'
@@ -23,41 +29,33 @@ endef
 
 empty :=
 
-define diff-file
-	diff -Naup '$(1)' '$(2)'
-
-endef
-
 # $1 - apis
 # $2 - manifests
-# $3 - output
 define run-crd-gen
 	'$(CONTROLLER_GEN)' \
 		schemapatch:manifests="$(2)" \
 		paths="$(subst $(empty) ,;,$(1))" \
-		output:dir="$(3)"
-	$$(foreach p,$$(wildcard $(2)/*.crd.yaml-merge-patch),$$(call patch-crd-yq,$$(subst $(2),$(3),$$(basename $$(p))).yaml,$$(p)))
-	$$(foreach p,$$(wildcard $(2)/*.crd.yaml-patch),$$(call patch-crd-yaml-patch,$$(subst $(2),$(3),$$(basename $$(p))).yaml,$$(p)))
+		'output:dir="$(2)"'
+	$$(foreach p,$$(wildcard $(2)/*.crd.yaml-merge-patch),$$(call patch-crd-yq,$$(basename $$(p)).yaml,$$(p)))
+	$$(foreach p,$$(wildcard $(2)/*.crd.yaml-patch),$$(call patch-crd-yaml-patch,$$(basename $$(p)).yaml,$$(p)))
+	$$(foreach p,$$(wildcard $(2)/*.crd.yaml),$$(call patch-crd-yq,$$(basename $$(p)).yaml,$$(p)))
 endef
 
 
 # $1 - target name
 # $2 - apis
 # $3 - manifests
-# $4 - output
 define add-crd-gen-internal
 
 update-codegen-crds-$(1): ensure-controller-gen ensure-yq ensure-yaml-patch
-	$(call run-crd-gen,$(2),$(3),$(4))
+	$(call run-crd-gen,$(2),$(3))
 .PHONY: update-codegen-crds-$(1)
 
 update-codegen-crds: update-codegen-crds-$(1)
 .PHONY: update-codegen-crds
 
-verify-codegen-crds-$(1): VERIFY_CODEGEN_CRD_TMP_DIR:=$$(shell mktemp -d)
-verify-codegen-crds-$(1): ensure-controller-gen ensure-yq ensure-yaml-patch
-	$(call run-crd-gen,$(2),$(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR))
-	$$(foreach p,$$(wildcard $(4)/*crd.yaml),$$(call diff-file,$$(p),$$(subst $(4),$$(VERIFY_CODEGEN_CRD_TMP_DIR),$$(p))))
+verify-codegen-crds-$(1): update-codegen-crds-$(1)
+	git diff --exit-code
 .PHONY: verify-codegen-crds-$(1)
 
 verify-codegen-crds: verify-codegen-crds-$(1)
@@ -65,6 +63,28 @@ verify-codegen-crds: verify-codegen-crds-$(1)
 
 endef
 
+
+# $1 - target name
+# $2 - apis
+# $3 - manifests
+# $4 - featureSet
+define add-crd-gen-for-featureset-internal
+
+update-codegen-$(4)-crds-$(1): ensure-controller-gen ensure-yq ensure-yaml-patch
+	OPENSHIFT_REQUIRED_FEATURESET=$(4) $(call run-crd-gen,$(2),$(3))
+.PHONY: update-codegen-$(4)-crds-$(1)
+
+update-codegen-$(4)-crds: update-codegen-$(4)-crds-$(1)
+.PHONY: update-codegen-$(4)-crds
+
+verify-codegen-$(4)-crds-$(1): update-codegen-$(4)-crds-$(1)
+	git diff --exit-code
+.PHONY: verify-codegen-$(4)-crds-$(1)
+
+verify-codegen-$(4)-crds: verify-codegen-$(4)-crds-$(1)
+.PHONY: verify-codegen-$(4)-crds
+
+endef
 
 update-generated: update-codegen-crds
 .PHONY: update-generated
@@ -80,5 +100,10 @@ verify: verify-generated
 
 
 define add-crd-gen
-$(eval $(call add-crd-gen-internal,$(1),$(2),$(3),$(4)))
+$(eval $(call add-crd-gen-internal,$(1),$(2),$(3)))
 endef
+
+define add-crd-gen-for-featureset
+$(eval $(call add-crd-gen-for-featureset-internal,$(1),$(2),$(3),$(5)))
+endef
+

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -406,7 +406,7 @@ github.com/openshift/api/template
 github.com/openshift/api/template/v1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/build-machinery-go v0.0.0-20220121085309-f94edc2d6874
+# github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 ## explicit; go 1.13
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make


### PR DESCRIPTION
This upgrades controller-gen to 0.9.2, matching Submariner 0.14.

Signed-off-by: Stephen Kitt <skitt@redhat.com>