### PR TITLE
Skip the suffix when updating the Submariner CR

### DIFF
--- a/hack/update-submariner.sh
+++ b/hack/update-submariner.sh
@@ -13,8 +13,10 @@ for project in admiral cloud-prepare submariner submariner-operator; do
     go get github.com/submariner-io/${project}@$1
 done
 
-sed -i "s/version: .*$/version: $1/" pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
 sed -i "s/submver=.*$/submver=${1#v}/" scripts/deploy.sh
+
+# Downstream builds track the main version without - suffixes
+sed -i "s/version: .*$/version: ${1%%-*}/" pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
 
 go mod tidy
 go mod vendor


### PR DESCRIPTION
Downstream builds track the main version, without pre-release suffixes (-rc1 etc.), even for pre-release builds. Skip the suffix when updating the corresponding CR.

Signed-off-by: Stephen Kitt <skitt@redhat.com>