### PR TITLE
Fix the versioned ignores for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
       - dependency-name: sigs.k8s.io/*
       # 2.5 tracks Submariner 0.12
       - dependency-name: github.com/submariner-io/*
-        ignore: ">= 0.13.0"
+        versions: ">= 0.13.0"
   - package-ecosystem: gomod
     target-branch: "release-2.6"
     directory: "/"
@@ -42,7 +42,7 @@ updates:
       - dependency-name: sigs.k8s.io/*
       # 2.6 tracks Submariner 0.13
       - dependency-name: github.com/submariner-io/*
-        ignore: ">= 0.14.0"
+        versions: ">= 0.14.0"
   - package-ecosystem: gomod
     target-branch: "release-2.7"
     directory: "/"
@@ -56,4 +56,4 @@ updates:
       - dependency-name: sigs.k8s.io/*
       # 2.7 tracks Submariner 0.14
       - dependency-name: github.com/submariner-io/*
-        ignore: ">= 0.15.0"
+        versions: ">= 0.15.0"


### PR DESCRIPTION
The element used to specify ignored versions is ignore/versions, not ignore/ignore; see
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore for details.

Signed-off-by: Stephen Kitt <skitt@redhat.com>