### PR TITLE
Configure airGappedDeployment based on SMConfig

### DIFF
--- a/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
@@ -15,6 +15,7 @@ spec:
   ceIPSecPSK: {{ .IPSecPSK }}
   clusterCIDR: ""
   globalCIDR: "{{ .GlobalCIDR }}"
+  airGappedDeployment: {{ .AirGappedDeployment }}
   loadBalancerEnabled: {{ .LoadBalancerEnabled }}
   clusterID: {{ .ClusterName }}
   colorCodes: blue


### PR DESCRIPTION
PR #524 adds support for specifing the airGappedDeployment status in SubmarinerConfig CR. In this PR, the same will be updated in the Submariners CR for the managedClusters based on the status of airGappedDeployment in submarinerConfig.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>