### PR TITLE
Restart addon pod on managed cluster after restore

### DIFF
--- a/pkg/hub/manager.go
+++ b/pkg/hub/manager.go
@@ -186,7 +186,14 @@ func (o *AddOnOptions) RunControllerManager(ctx context.Context, controllerConte
 		return err
 	}
 
-	err = mgr.AddAgent(submarineraddonagent.NewAddOnAgent(kubeClient, controllerContext.EventRecorder, o.AgentImage))
+	localCluster, err := clusterClient.ClusterV1().ManagedClusters().Get(context.TODO(), "local-cluster", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	host := localCluster.Spec.ManagedClusterClientConfigs[0].URL
+
+	err = mgr.AddAgent(submarineraddonagent.NewAddOnAgent(kubeClient, controllerContext.EventRecorder, o.AgentImage, host))
 	if err != nil {
 		return err
 	}

--- a/pkg/hub/submarineraddonagent/agent.go
+++ b/pkg/hub/submarineraddonagent/agent.go
@@ -73,15 +73,17 @@ type addOnAgent struct {
 	kubeClient    kubernetes.Interface
 	recorder      events.Recorder
 	agentImage    string
+	hubHost       string
 	resourceCache resourceapply.ResourceCache
 }
 
 // NewAddOnAgent returns an instance of addOnAgent.
-func NewAddOnAgent(kubeClient kubernetes.Interface, recorder events.Recorder, agentImage string) agent.AgentAddon {
+func NewAddOnAgent(kubeClient kubernetes.Interface, recorder events.Recorder, agentImage, hubHost string) agent.AgentAddon {
 	return &addOnAgent{
 		kubeClient:    kubeClient,
 		recorder:      recorder,
 		agentImage:    agentImage,
+		hubHost:       hubHost,
 		resourceCache: resourceapply.NewResourceCache(),
 	}
 }
@@ -109,11 +111,13 @@ func (a *addOnAgent) Manifests(cluster *clusterv1.ManagedCluster, addon *addonap
 		ClusterName           string
 		AddonInstallNamespace string
 		Image                 string
+		HubHost               string
 	}{
 		KubeConfigSecret:      fmt.Sprintf("%s-hub-kubeconfig", a.GetAgentAddonOptions().AddonName),
 		AddonInstallNamespace: installNamespace,
 		ClusterName:           cluster.Name,
 		Image:                 a.agentImage,
+		HubHost:               a.hubHost,
 	}
 
 	for _, file := range deploymentFiles {

--- a/pkg/hub/submarineraddonagent/agent_test.go
+++ b/pkg/hub/submarineraddonagent/agent_test.go
@@ -207,7 +207,7 @@ func newTestDriver() *testDriver {
 
 	BeforeEach(func() {
 		t.kubeClient = kubefake.NewSimpleClientset()
-		t.addOnAgent = submarineraddonagent.NewAddOnAgent(t.kubeClient, events.NewLoggingEventRecorder("test"), "test")
+		t.addOnAgent = submarineraddonagent.NewAddOnAgent(t.kubeClient, events.NewLoggingEventRecorder("test"), "test", "")
 	})
 
 	return t

--- a/pkg/hub/submarineraddonagent/manifests/deployment.yaml
+++ b/pkg/hub/submarineraddonagent/manifests/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       containers:
       - name: submariner-addon
         image: {{ .Image }}
+        env:
+        - name: HUB_HOST
+          value: "{{ .HubHost }}"
         args:
           - "/submariner"
           - "agent"

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -21,6 +21,7 @@ import (
 	addonclientset "open-cluster-management.io/api/client/addon/clientset/versioned"
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	workclientset "open-cluster-management.io/api/client/work/clientset/versioned"
+	clusterV1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -119,6 +120,16 @@ var _ = BeforeSuite(func() {
 	// prepare open-cluster-management namespaces
 	_, err = kubeClient.CoreV1().Namespaces().Create(context.Background(), util.NewManagedClusterNamespace("open-cluster-management"),
 		metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	// create local cluster with URL in ClientConfig
+	localCluster := util.NewManagedCluster("local-cluster", map[string]string{})
+	localCluster.Spec.ManagedClusterClientConfigs = []clusterV1.ClientConfig{
+		{
+			URL: "https://dummy:443",
+		},
+	}
+	_, err = clusterClient.ClusterV1().ManagedClusters().Create(context.Background(), localCluster, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
 	// start submariner broker and agent controller


### PR DESCRIPTION
After a backup+restore, submariner-addon pods on managed cluster are still trying to reach old hub. The pods need to be restarted to pick up new hub config.

Add an env variable to submariner-addon deployment with hub's API server. When new hub is restored, it will result in forced restart of the pods on managed cluster.

Fixes #584

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>