### PR TITLE
Mark the test target as phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,5 +158,6 @@ build:
 
 test:
 	$(GO) test -race ./pkg/...
+.PHONY: test
 
 test-integration: vendor


### PR DESCRIPTION
... otherwise the test directory satisfies the target, and the tests don't run.

Signed-off-by: Stephen Kitt <skitt@redhat.com>