### PR TITLE
Don't open metrics ports in cloud

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -7,7 +7,6 @@ Submariner with ACM has a few requirements to get started:
 3. ACM only supports non-overlapping Pod and Service CIDRs between managed clusters using Submariner to connect workloads across each other at the current stage.
 4. IP reachability between the gateway nodes. When connecting two clusters, at least one of the clusters should have a publicly routable IP address designated to the Gateway node.
 5. Ensure that firewall configuration allows 4800/UDP across all nodes in the managed cluster in both directions.
-6. Ensure that firewall configuration allows ingress 8080/TCP on the Gateway nodes so that other nodes in the cluster can access it.
 
 Refer to [Prerequisites of Submariner](https://submariner.io/getting-started/#prerequisites) for the detailed prerequisites.
 
@@ -51,29 +50,7 @@ Use `SubmarinerConfig` API to build the cluster environment. See [SubmarinerConf
    > Replace <frontend-ip-name> with your cluster frontend IP configuration name.  
    > Replace <nic-name> with your network interface (NIC).
 
-2. Create one load balancing inbound NAT rules to forward Submariner gateway metrics service request.
-
-    ```bash
-    # create inbound nat rule
-    $ az network lb inbound-nat-rule create --lb-name <lb-name> \
-    --resource-group <res-group> \
-    --name <name> \
-    --protocol Tcp --frontend-port 8080 --backend-port 8080 \
-    --frontend-ip-name <frontend-ip-name>
-
-    # add your vm network interface to the created inbound nat rule
-    $ az network nic ip-config inbound-nat-rule add \
-    --lb-name <lb-name> --resource-group <res-group> \
-    --inbound-nat-rule <name> \
-    --nic-name <nic-name> --ip-config-name pipConfig
-    ```
-   > Replace <lb-name> with your load balancer name.  
-   > Replace <res-group> with your resource group name.  
-   > Replace <name> with your load balancing inbound NAT rule name.  
-   > Replace <frontend-ip-name> with your cluster frontend IP configuration name.  
-   > Replace <nic-name> with your network interface (NIC).
-
-3. Create NSG (network security groups) security rules on your Azure to open IPsec IKE (by default 500/UDP) and NAT traversal ports (by default 4500/UDP) for Submariner.
+2. Create NSG (network security groups) security rules on your Azure to open IPsec IKE (by default 500/UDP) and NAT traversal ports (by default 4500/UDP) for Submariner.
 
     ```bash
     $ az network nsg rule create --resource-group <res-group> \
@@ -92,7 +69,7 @@ Use `SubmarinerConfig` API to build the cluster environment. See [SubmarinerConf
    > Replace <name> with your rule name.  
    > Replace <ipsec-port> with your IPsec port.
 
-4. Create the NSG rules to open 4800/UDP port to encapsulate Pod traffic from the worker and master nodes to the Submariner Gateway nodes.
+3. Create the NSG rules to open 4800/UDP port to encapsulate Pod traffic from the worker and master nodes to the Submariner Gateway nodes.
 
     ```bash
     $ az network nsg rule create --resource-group <res-group> \
@@ -110,25 +87,7 @@ Use `SubmarinerConfig` API to build the cluster environment. See [SubmarinerConf
    > Replace <priority> with your rule priority.  
    > Replace <name> with your rule name.
 
-5. Create the NSG rules to open 8080/TCP port to export metrics service from the Submariner gateway.
-
-    ```bash
-    $ az network nsg rule create --resource-group <res-group> \
-    --nsg-name <nsg-name> --priority <priority> \
-    --name <name> --direction Inbound --access Allow \
-    --protocol Tcp --destination-port-ranges 8080 \
-
-    $ az network nsg rule create --resource-group <res-group> \
-    --nsg-name <nsg-name> --priority <priority> \
-    --name <name> --direction Outbound --access Allow \
-    --protocol Udp --destination-port-ranges 8080
-    ```
-   > Replace <res-group> with your resource group name.  
-   > Replace <nsg-name> with your NSG name.  
-   > Replace <priority> with your rule priority.  
-   > Replace <name> with your rule name.
-
-6. Label your worker node with the `submariner.io/gateway=true` in your cluster 
+4. Label your worker node with the `submariner.io/gateway=true` in your cluster 
    ```
    kubectl label nodes <worker-node-name> "submariner.io/gateway=true" --overwrite
    ```

--- a/pkg/cloud/aws/aws.go
+++ b/pkg/cloud/aws/aws.go
@@ -122,8 +122,6 @@ func (a *awsProvider) PrepareSubmarinerClusterEnv() error {
 	if err := a.cloudPrepare.PrepareForSubmariner(cpapi.PrepareForSubmarinerInput{
 		InternalPorts: []cpapi.PortSpec{
 			{Port: constants.SubmarinerRoutePort, Protocol: "udp"},
-			{Port: constants.SubmarinerGatewayMetricsPort, Protocol: "tcp"},
-			{Port: constants.SubmarinerGlobalnetMetricsPort, Protocol: "tcp"},
 		},
 	}, a.reporter); err != nil {
 		return err

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -29,16 +29,14 @@ const (
 )
 
 type azureProvider struct {
-	infraID              string
-	nattPort             uint16
-	routePort            string
-	gatewayMetricsPort   uint16
-	globalnetMetricsPort uint16
-	cloudPrepare         api.Cloud
-	reporter             submreporter.Interface
-	gwDeployer           api.GatewayDeployer
-	gateways             int
-	nattDiscoveryPort    int64
+	infraID           string
+	nattPort          uint16
+	routePort         string
+	cloudPrepare      api.Cloud
+	reporter          submreporter.Interface
+	gwDeployer        api.GatewayDeployer
+	gateways          int
+	nattDiscoveryPort int64
 }
 
 func NewAzureProvider(
@@ -103,16 +101,14 @@ func NewAzureProvider(
 	cloudPrepare := azure.NewCloud(&cloudInfo)
 
 	return &azureProvider{
-		infraID:              infraID,
-		nattPort:             uint16(nattPort),
-		routePort:            strconv.Itoa(constants.SubmarinerRoutePort),
-		gatewayMetricsPort:   constants.SubmarinerGatewayMetricsPort,
-		globalnetMetricsPort: constants.SubmarinerGlobalnetMetricsPort,
-		cloudPrepare:         cloudPrepare,
-		gwDeployer:           gwDeployer,
-		reporter:             reporter.NewEventRecorderWrapper("AzureCloudProvider", eventRecorder),
-		nattDiscoveryPort:    int64(nattDiscoveryPort),
-		gateways:             gateways,
+		infraID:           infraID,
+		nattPort:          uint16(nattPort),
+		routePort:         strconv.Itoa(constants.SubmarinerRoutePort),
+		cloudPrepare:      cloudPrepare,
+		gwDeployer:        gwDeployer,
+		reporter:          reporter.NewEventRecorderWrapper("AzureCloudProvider", eventRecorder),
+		nattDiscoveryPort: int64(nattDiscoveryPort),
+		gateways:          gateways,
 	}, nil
 }
 
@@ -122,8 +118,6 @@ func NewAzureProvider(
 //    - NAT traversal port (by default 4500/UDP)
 //    - 4800/UDP port to encapsulate Pod traffic from worker and master nodes to the Submariner Gateway nodes
 //    - ESP & AH protocols for private-ip to private-ip gateway communications
-// 2. create the inbound and outbound firewall rules to open 8080/TCP, 8081/TCP port to export metrics service from the
-//    Submariner gateway
 func (r *azureProvider) PrepareSubmarinerClusterEnv() error {
 	// TODO For ovn the port 4800 need not be opened.
 	if err := r.gwDeployer.Deploy(api.GatewayDeployInput{
@@ -141,8 +135,6 @@ func (r *azureProvider) PrepareSubmarinerClusterEnv() error {
 	input := api.PrepareForSubmarinerInput{
 		InternalPorts: []api.PortSpec{
 			{Port: constants.SubmarinerRoutePort, Protocol: "udp"},
-			{Port: r.gatewayMetricsPort, Protocol: "tcp"},
-			{Port: r.globalnetMetricsPort, Protocol: "tcp"},
 		},
 	}
 	err := r.cloudPrepare.PrepareForSubmariner(input, r.reporter)
@@ -157,7 +149,6 @@ func (r *azureProvider) PrepareSubmarinerClusterEnv() error {
 // CleanUpSubmarinerClusterEnv clean up submariner cluster environment on Azure after the SubmarinerConfig was deleted
 // 1. delete any dedicated gateways that were previously deployed.
 // 2. delete the inbound and outbound firewall rules to close submariner ports
-// 3. delete the inbound and outbound firewall rules to close submariner metrics port
 func (r azureProvider) CleanUpSubmarinerClusterEnv() error {
 	err := r.gwDeployer.Cleanup(r.reporter)
 	if err != nil {

--- a/pkg/cloud/gcp/gcp.go
+++ b/pkg/cloud/gcp/gcp.go
@@ -32,16 +32,14 @@ const (
 )
 
 type gcpProvider struct {
-	infraID              string
-	nattPort             uint16
-	routePort            string
-	gatewayMetricsPort   uint16
-	globalnetMetricsPort uint16
-	cloudPrepare         api.Cloud
-	reporter             submreporter.Interface
-	gwDeployer           api.GatewayDeployer
-	gateways             int
-	nattDiscoveryPort    int64
+	infraID           string
+	nattPort          uint16
+	routePort         string
+	cloudPrepare      api.Cloud
+	reporter          submreporter.Interface
+	gwDeployer        api.GatewayDeployer
+	gateways          int
+	nattDiscoveryPort int64
 }
 
 func NewGCPProvider(
@@ -96,16 +94,14 @@ func NewGCPProvider(
 		"", true, k8sClient)
 
 	return &gcpProvider{
-		infraID:              infraID,
-		nattPort:             uint16(nattPort),
-		routePort:            strconv.Itoa(constants.SubmarinerRoutePort),
-		gatewayMetricsPort:   constants.SubmarinerGatewayMetricsPort,
-		globalnetMetricsPort: constants.SubmarinerGlobalnetMetricsPort,
-		cloudPrepare:         cloudPrepare,
-		gwDeployer:           gwDeployer,
-		reporter:             reporter.NewEventRecorderWrapper("GCPCloudProvider", eventRecorder),
-		nattDiscoveryPort:    int64(nattDiscoveryPort),
-		gateways:             gateways,
+		infraID:           infraID,
+		nattPort:          uint16(nattPort),
+		routePort:         strconv.Itoa(constants.SubmarinerRoutePort),
+		cloudPrepare:      cloudPrepare,
+		gwDeployer:        gwDeployer,
+		reporter:          reporter.NewEventRecorderWrapper("GCPCloudProvider", eventRecorder),
+		nattDiscoveryPort: int64(nattDiscoveryPort),
+		gateways:          gateways,
 	}, nil
 }
 
@@ -115,7 +111,6 @@ func NewGCPProvider(
 //    - IPsec IKE port (by default 500/UDP)
 //    - NAT traversal port (by default 4500/UDP)
 //    - 4800/UDP port to encapsulate Pod traffic from worker and master nodes to the Submariner Gateway nodes
-// 2. create the inbound and outbound firewall rules to open 8080/TCP port to export metrics service from the Submariner gateway
 func (g *gcpProvider) PrepareSubmarinerClusterEnv() error {
 	if err := g.gwDeployer.Deploy(api.GatewayDeployInput{
 		PublicPorts: []api.PortSpec{
@@ -133,8 +128,6 @@ func (g *gcpProvider) PrepareSubmarinerClusterEnv() error {
 	input := api.PrepareForSubmarinerInput{
 		InternalPorts: []api.PortSpec{
 			{Port: constants.SubmarinerRoutePort, Protocol: "udp"},
-			{Port: g.gatewayMetricsPort, Protocol: "tcp"},
-			{Port: g.globalnetMetricsPort, Protocol: "tcp"},
 		},
 	}
 	err := g.cloudPrepare.PrepareForSubmariner(input, g.reporter)
@@ -148,7 +141,6 @@ func (g *gcpProvider) PrepareSubmarinerClusterEnv() error {
 
 // CleanUpSubmarinerClusterEnv clean up submariner cluster environment on GCP after the SubmarinerConfig was deleted
 // 1. delete the inbound and outbound firewall rules to close submariner ports
-// 2. delete the inbound and outbound firewall rules to close submariner metrics port
 func (g *gcpProvider) CleanUpSubmarinerClusterEnv() error {
 	err := g.gwDeployer.Cleanup(g.reporter)
 	if err != nil {

--- a/pkg/cloud/rhos/rhos.go
+++ b/pkg/cloud/rhos/rhos.go
@@ -36,16 +36,14 @@ const (
 )
 
 type rhosProvider struct {
-	infraID              string
-	nattPort             uint16
-	routePort            string
-	gatewayMetricsPort   uint16
-	globalnetMetricsPort uint16
-	cloudPrepare         api.Cloud
-	reporter             submreporter.Interface
-	gwDeployer           api.GatewayDeployer
-	gateways             int
-	nattDiscoveryPort    int64
+	infraID           string
+	nattPort          uint16
+	routePort         string
+	cloudPrepare      api.Cloud
+	reporter          submreporter.Interface
+	gwDeployer        api.GatewayDeployer
+	gateways          int
+	nattDiscoveryPort int64
 }
 
 func NewRHOSProvider(
@@ -98,16 +96,14 @@ func NewRHOSProvider(
 		"", cloudEntry, true)
 
 	return &rhosProvider{
-		infraID:              infraID,
-		nattPort:             uint16(nattPort),
-		routePort:            strconv.Itoa(constants.SubmarinerRoutePort),
-		gatewayMetricsPort:   constants.SubmarinerGatewayMetricsPort,
-		globalnetMetricsPort: constants.SubmarinerGlobalnetMetricsPort,
-		cloudPrepare:         cloudPrepare,
-		gwDeployer:           gwDeployer,
-		reporter:             reporter.NewEventRecorderWrapper("RHOSCloudProvider", eventRecorder),
-		nattDiscoveryPort:    int64(nattDiscoveryPort),
-		gateways:             gateways,
+		infraID:           infraID,
+		nattPort:          uint16(nattPort),
+		routePort:         strconv.Itoa(constants.SubmarinerRoutePort),
+		cloudPrepare:      cloudPrepare,
+		gwDeployer:        gwDeployer,
+		reporter:          reporter.NewEventRecorderWrapper("RHOSCloudProvider", eventRecorder),
+		nattDiscoveryPort: int64(nattDiscoveryPort),
+		gateways:          gateways,
 	}, nil
 }
 
@@ -117,8 +113,6 @@ func NewRHOSProvider(
 //    - NAT traversal port (by default 4500/UDP)
 //    - 4800/UDP port to encapsulate Pod traffic from worker and master nodes to the Submariner Gateway nodes
 //    - ESP & AH protocols for private-ip to private-ip gateway communications
-// 2. create the inbound and outbound firewall rules to open 8080/TCP, 8081/TCP port to export metrics service from the
-//    Submariner gateway
 func (r *rhosProvider) PrepareSubmarinerClusterEnv() error {
 	if err := r.gwDeployer.Deploy(api.GatewayDeployInput{
 		PublicPorts: []api.PortSpec{
@@ -135,8 +129,6 @@ func (r *rhosProvider) PrepareSubmarinerClusterEnv() error {
 	input := api.PrepareForSubmarinerInput{
 		InternalPorts: []api.PortSpec{
 			{Port: constants.SubmarinerRoutePort, Protocol: "udp"},
-			{Port: r.gatewayMetricsPort, Protocol: "tcp"},
-			{Port: r.globalnetMetricsPort, Protocol: "tcp"},
 		},
 	}
 	err := r.cloudPrepare.PrepareForSubmariner(input, r.reporter)
@@ -151,7 +143,6 @@ func (r *rhosProvider) PrepareSubmarinerClusterEnv() error {
 // CleanUpSubmarinerClusterEnv clean up submariner cluster environment on RHOS after the SubmarinerConfig was deleted
 // 1. delete any dedicated gateways that were previously deployed.
 // 2. delete the inbound and outbound firewall rules to close submariner ports
-// 3. delete the inbound and outbound firewall rules to close submariner metrics port
 func (r rhosProvider) CleanUpSubmarinerClusterEnv() error {
 	err := r.gwDeployer.Cleanup(r.reporter)
 	if err != nil {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -11,12 +11,7 @@ const (
 
 	IPSecPSKSecretName = "submariner-ipsec-psk"
 
-	SubmarinerNatTPort           = 4500
-	SubmarinerNatTDiscoveryPort  = 4900
-	SubmarinerRoutePort          = 4800
-	SubmarinerGatewayMetricsPort = 8080
-
-	// TODO: Currently we are configuring this Port unconditionally. This is an internal port, but can be
-	// enabled only in Globalnet deployments.
-	SubmarinerGlobalnetMetricsPort = 8081
+	SubmarinerNatTPort          = 4500
+	SubmarinerNatTDiscoveryPort = 4900
+	SubmarinerRoutePort         = 4800
 )


### PR DESCRIPTION
Submariner 0.14.0 no longer requires metrics ports to be open on cloud hosts to allow access to metrics. Do not open these ports:
  * 8080
  * 8081

Fixes #488

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>