### PR TITLE
Use correct version of submariner images in kind

### DIFF
--- a/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
@@ -30,7 +30,7 @@ spec:
     submariner-gateway: {{ .SubmarinerGatewayImage }}
     {{- end}}
     {{- if .SubmarinerRouteAgentImage }}
-    submariner-route-agent: {{ .SubmarinerRouteAgentImage }}
+    submariner-routeagent: {{ .SubmarinerRouteAgentImage }}
     {{- end}}
     {{- if .SubmarinerGlobalnetImage }}
     submariner-globalnet: {{ .SubmarinerGlobalnetImage }}
@@ -39,10 +39,10 @@ spec:
     submariner-networkplugin-syncer: {{ .SubmarinerNetworkPluginSyncerImage }}
     {{- end}}
     {{- if .LighthouseAgentImage }}
-    lighthouse-agent: {{ .LighthouseAgentImage }}
+    submariner-lighthouse-agent: {{ .LighthouseAgentImage }}
     {{- end}}
     {{- if .LighthouseCoreDNSImage }}
-    lighthouse-coredns: {{ .LighthouseCoreDNSImage }}
+    submariner-lighthouse-coredns: {{ .LighthouseCoreDNSImage }}
     {{- end}}
     {{- if .MetricsProxyImage }}
     submariner-metrics-proxy: {{ .MetricsProxyImage }}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source scripts/clusters.sh
-k8s_version="v1.23.4"
+source scripts/vars.sh
 
 if [ "$1"x = "cleanup"x ]; then
     for cluster in "${clusters[@]}"; do
@@ -205,8 +205,6 @@ spec:
     sourceNamespace: olm
 EOF
 
-    submrepo="quay.io/submariner"
-    submver=0.14.0-rc2
     kubectl patch submarinerconfigs submariner -n ${cluster} --type "json" -p '[
 {"op":"add","path":"/spec/imagePullSpecs/submarinerImagePullSpec","value":"'${submrepo}'/submariner-gateway:'${submver}'"},
 {"op":"add","path":"/spec/imagePullSpecs/submarinerRouteAgentImagePullSpec","value":"'${submrepo}'/submariner-route-agent:'${submver}'"},

--- a/scripts/vars.sh
+++ b/scripts/vars.sh
@@ -1,0 +1,3 @@
+k8s_version="v1.23.4"
+submrepo="quay.io/submariner"
+submver="0.14.0"


### PR DESCRIPTION
When deploying addon in kind, it ignores the submariner repositrory and version. This causes a discrepancy where operator is using older version [0.11.0] while all agents are on latest version configured. Also, for route agent and lighthouse images, overrides don't work correctly. This is because component name is incorrect.

This fix requires following changes:
 1. Wait for all submariner manifestworks to be created and available.
 2. Set `skipOperatorGroup` annotation on submarinerconfigs
 3. Patch submariner-operator deployments to use repo and version as configured.
 4. Use correct component names for all lighthouse and routeagent image overrides.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>