### PR TITLE
Don't open vxlan port for OVN

### DIFF
--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strconv"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/pkg/errors"
@@ -16,6 +16,7 @@ import (
 	"github.com/submariner-io/cloud-prepare/pkg/azure"
 	"github.com/submariner-io/cloud-prepare/pkg/k8s"
 	"github.com/submariner-io/cloud-prepare/pkg/ocp"
+	"github.com/submariner-io/submariner/pkg/cni"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -27,7 +28,7 @@ const (
 type azureProvider struct {
 	infraID           string
 	nattPort          uint16
-	routePort         string
+	cniType           string
 	cloudPrepare      api.Cloud
 	reporter          submreporter.Interface
 	gwDeployer        api.GatewayDeployer
@@ -84,7 +85,7 @@ func NewProvider(info *provider.Info) (*azureProvider, error) {
 	return &azureProvider{
 		infraID:           info.InfraID,
 		nattPort:          uint16(info.IPSecNATTPort),
-		routePort:         strconv.Itoa(constants.SubmarinerRoutePort),
+		cniType:           info.NetworkType,
 		cloudPrepare:      cloudPrepare,
 		gwDeployer:        gwDeployer,
 		reporter:          reporter.NewEventRecorderWrapper("AzureCloudProvider", info.EventRecorder),
@@ -113,11 +114,12 @@ func (r *azureProvider) PrepareSubmarinerClusterEnv() error {
 		return err
 	}
 
-	err := r.cloudPrepare.OpenPorts([]api.PortSpec{
-		{Port: constants.SubmarinerRoutePort, Protocol: "udp"},
-	}, r.reporter)
-	if err != nil {
-		return err
+	if !strings.EqualFold(r.cniType, cni.OVNKubernetes) {
+		if err := r.cloudPrepare.OpenPorts([]api.PortSpec{
+			{Port: constants.SubmarinerRoutePort, Protocol: "udp"},
+		}, r.reporter); err != nil {
+			return err
+		}
 	}
 
 	r.reporter.Success("The Submariner cluster environment has been set up on Azure")

--- a/pkg/hub/submarineragent/controller.go
+++ b/pkg/hub/submarineragent/controller.go
@@ -475,9 +475,16 @@ func (c *submarinerAgentController) updateSubmarinerConfigStatus(ctx context.Con
 		Message: "SubmarinerConfig was applied",
 	}
 
+	managedClusterInfo := getManagedClusterInfo(managedCluster)
+
+	// NetworkType is set by spoke cluster, make sure we don't reset it
+	if submarinerConfig.Status.ManagedClusterInfo.NetworkType != "" {
+		managedClusterInfo.NetworkType = submarinerConfig.Status.ManagedClusterInfo.NetworkType
+	}
+
 	_, updated, err := submarinerconfig.UpdateStatus(ctx,
 		c.configClient.SubmarineraddonV1alpha1().SubmarinerConfigs(submarinerConfig.Namespace), submarinerConfig.Name,
-		submarinerconfig.UpdateStatusFn(condition, getManagedClusterInfo(managedCluster)))
+		submarinerconfig.UpdateStatusFn(condition, managedClusterInfo))
 
 	if updated {
 		c.eventRecorder.Eventf("SubmarinerConfigApplied", "SubmarinerConfig %q was applied for managed cluster %q",


### PR DESCRIPTION
Submariner doesn't use VxLan port [4800] when CNI is OVNKubernetes. So no need to open this port in cloud.

Fixes #388 

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>