### PR TITLE
Expose the "insecure broker connections" setting

### DIFF
--- a/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -115,6 +115,12 @@ spec:
                   lighthouseCoreDNSImagePullSpec:
                     description: LighthouseCoreDNSImagePullSpec represents the desired image of lighthouse coredns.
                     type: string
+                  metricsProxyImagePullSpec:
+                    description: MetricsProxyImagePullSpec represents the desired image of the metrics proxy.
+                    type: string
+                  nettestImagePullSpec:
+                    description: NettestImagePullSpec represents the desired image of nettest.
+                    type: string
                   submarinerGlobalnetImagePullSpec:
                     description: SubmarinerGlobalnetImagePullSpec represents the desired image of the submariner globalnet.
                     type: string
@@ -127,13 +133,11 @@ spec:
                   submarinerRouteAgentImagePullSpec:
                     description: SubmarinerRouteAgentImagePullSpec represents the desired image of the submariner route agent.
                     type: string
-                  metricsProxyImagePullSpec:
-                    description: MetricsProxyImagePullSpec represents the desired image of the metrics proxy.
-                    type: string
-                  nettestImagePullSpec:
-                    description: NettestImagePullSpec represents the desired image of nettest.
-                    type: string
                 type: object
+              insecureBrokerConnection:
+                default: false
+                description: InsecureBrokerConnection disables certificate validation when contacting the broker. This is useful for scenarios where the certificate chain isn't the same everywhere, e.g. with self-signed certificates with a different trust chain in each cluster.
+                type: boolean
               loadBalancerEnable:
                 default: false
                 description: LoadBalancerEnable enables or disables load balancer mode. When enabled, a LoadBalancer is created in the submariner-operator namespace (default false).

--- a/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -132,6 +132,10 @@ spec:
                     description: SubmarinerRouteAgentImagePullSpec represents the desired image of the submariner route agent.
                     type: string
                 type: object
+              insecureBrokerConnection:
+                default: false
+                description: InsecureBrokerConnection disables certificate validation when contacting the broker. This is useful for scenarios where the certificate chain isn't the same everywhere, e.g. with self-signed certificates with a different trust chain in each cluster.
+                type: boolean
               loadBalancerEnable:
                 default: false
                 description: LoadBalancerEnable enables or disables load balancer mode. When enabled, a LoadBalancer is created in the submariner-operator namespace (default false).

--- a/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
+++ b/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
@@ -115,6 +115,12 @@ spec:
                   lighthouseCoreDNSImagePullSpec:
                     description: LighthouseCoreDNSImagePullSpec represents the desired image of lighthouse coredns.
                     type: string
+                  metricsProxyImagePullSpec:
+                    description: MetricsProxyImagePullSpec represents the desired image of the metrics proxy.
+                    type: string
+                  nettestImagePullSpec:
+                    description: NettestImagePullSpec represents the desired image of nettest.
+                    type: string
                   submarinerGlobalnetImagePullSpec:
                     description: SubmarinerGlobalnetImagePullSpec represents the desired image of the submariner globalnet.
                     type: string
@@ -127,13 +133,11 @@ spec:
                   submarinerRouteAgentImagePullSpec:
                     description: SubmarinerRouteAgentImagePullSpec represents the desired image of the submariner route agent.
                     type: string
-                  metricsProxyImagePullSpec:
-                    description: MetricsProxyImagePullSpec represents the desired image of the metrics proxy.
-                    type: string
-                  nettestImagePullSpec:
-                    description: NettestImagePullSpec represents the desired image of nettest.
-                    type: string
                 type: object
+              insecureBrokerConnection:
+                default: false
+                description: InsecureBrokerConnection disables certificate validation when contacting the broker. This is useful for scenarios where the certificate chain isn't the same everywhere, e.g. with self-signed certificates with a different trust chain in each cluster.
+                type: boolean
               loadBalancerEnable:
                 default: false
                 description: LoadBalancerEnable enables or disables load balancer mode. When enabled, a LoadBalancer is created in the submariner-operator namespace (default false).

--- a/pkg/apis/submarinerconfig/v1alpha1/types.go
+++ b/pkg/apis/submarinerconfig/v1alpha1/types.go
@@ -67,6 +67,13 @@ type SubmarinerConfigSpec struct {
 	// +kubebuilder:default=false
 	LoadBalancerEnable bool `json:"loadBalancerEnable"`
 
+	// InsecureBrokerConnection disables certificate validation when contacting the broker.
+	// This is useful for scenarios where the certificate chain isn't the same everywhere, e.g. with self-signed
+	// certificates with a different trust chain in each cluster.
+	// +optional
+	// +kubebuilder:default=false
+	InsecureBrokerConnection bool `json:"insecureBrokerConnection"`
+
 	// CredentialsSecret is a reference to the secret with a certain cloud platform
 	// credentials, the supported platform includes AWS, GCP, Azure, ROKS and OSD.
 	// The submariner-addon will use these credentials to prepare Submariner cluster

--- a/pkg/apis/submarinerconfig/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/pkg/apis/submarinerconfig/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -90,19 +90,20 @@ func (SubmarinerConfigList) SwaggerDoc() map[string]string {
 }
 
 var map_SubmarinerConfigSpec = map[string]string{
-	"":                    "SubmarinerConfigSpec describes the configuration of the Submariner.",
-	"cableDriver":         "CableDriver represents the submariner cable driver implementation. Available options are libreswan (default) strongswan, wireguard, and vxlan.",
-	"globalCIDR":          "GlobalCIDR specifies the global CIDR used by the cluster.",
-	"IPSecIKEPort":        "IPSecIKEPort represents IPsec IKE port (default 500).",
-	"IPSecNATTPort":       "IPSecNATTPort represents IPsec NAT-T port (default 4500).",
-	"NATTDiscoveryPort":   "NATTDiscoveryPort specifies the port used for NAT-T Discovery (default UDP/4900).",
-	"NATTEnable":          "NATTEnable represents IPsec NAT-T enabled (default true).",
-	"airGappedDeployment": "AirGappedDeployment specifies that the cluster is in an air-gapped environment without access to external servers.",
-	"loadBalancerEnable":  "LoadBalancerEnable enables or disables load balancer mode. When enabled, a LoadBalancer is created in the submariner-operator namespace (default false).",
-	"credentialsSecret":   "CredentialsSecret is a reference to the secret with a certain cloud platform credentials, the supported platform includes AWS, GCP, Azure, ROKS and OSD. The submariner-addon will use these credentials to prepare Submariner cluster environment. If the submariner cluster environment requires submariner-addon preparation, this field should be specified.",
-	"subscriptionConfig":  "SubscriptionConfig represents a Submariner subscription. SubscriptionConfig can be used to customize the Submariner subscription.",
-	"imagePullSpecs":      "ImagePullSpecs represents the desired images of submariner components installed on the managed cluster. If not specified, the default submariner images that was defined by submariner operator will be used.",
-	"gatewayConfig":       "GatewayConfig represents the gateways configuration of the Submariner.",
+	"":                         "SubmarinerConfigSpec describes the configuration of the Submariner.",
+	"cableDriver":              "CableDriver represents the submariner cable driver implementation. Available options are libreswan (default) strongswan, wireguard, and vxlan.",
+	"globalCIDR":               "GlobalCIDR specifies the global CIDR used by the cluster.",
+	"IPSecIKEPort":             "IPSecIKEPort represents IPsec IKE port (default 500).",
+	"IPSecNATTPort":            "IPSecNATTPort represents IPsec NAT-T port (default 4500).",
+	"NATTDiscoveryPort":        "NATTDiscoveryPort specifies the port used for NAT-T Discovery (default UDP/4900).",
+	"NATTEnable":               "NATTEnable represents IPsec NAT-T enabled (default true).",
+	"airGappedDeployment":      "AirGappedDeployment specifies that the cluster is in an air-gapped environment without access to external servers.",
+	"loadBalancerEnable":       "LoadBalancerEnable enables or disables load balancer mode. When enabled, a LoadBalancer is created in the submariner-operator namespace (default false).",
+	"insecureBrokerConnection": "InsecureBrokerConnection disables certificate validation when contacting the broker. This is useful for scenarios where the certificate chain isn't the same everywhere, e.g. with self-signed certificates with a different trust chain in each cluster.",
+	"credentialsSecret":        "CredentialsSecret is a reference to the secret with a certain cloud platform credentials, the supported platform includes AWS, GCP, Azure, ROKS and OSD. The submariner-addon will use these credentials to prepare Submariner cluster environment. If the submariner cluster environment requires submariner-addon preparation, this field should be specified.",
+	"subscriptionConfig":       "SubscriptionConfig represents a Submariner subscription. SubscriptionConfig can be used to customize the Submariner subscription.",
+	"imagePullSpecs":           "ImagePullSpecs represents the desired images of submariner components installed on the managed cluster. If not specified, the default submariner images that was defined by submariner operator will be used.",
+	"gatewayConfig":            "GatewayConfig represents the gateways configuration of the Submariner.",
 }
 
 func (SubmarinerConfigSpec) SwaggerDoc() map[string]string {

--- a/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
@@ -9,6 +9,7 @@ spec:
   brokerK8sApiServerToken: {{ .BrokerToken }}
   brokerK8sCA: {{ .BrokerCA }}
   brokerK8sRemoteNamespace: {{ .BrokerNamespace }}
+  brokerK8sInsecure: {{ .InsecureBrokerConnection }}
   cableDriver: {{ .CableDriver }}
   ceIPSecDebug: false
   ceIPSecNATTPort: {{ .IPSecNATTPort }}

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo.go
@@ -59,6 +59,7 @@ type SubmarinerBrokerInfo struct {
 	AirGappedDeployment                bool
 	NATEnabled                         bool
 	LoadBalancerEnabled                bool
+	InsecureBrokerConnection           bool
 	IPSecNATTPort                      int
 	InstallationNamespace              string
 	InstallPlanApproval                string
@@ -191,6 +192,7 @@ func applySubmarinerConfig(brokerInfo *SubmarinerBrokerInfo, submarinerConfig *c
 	brokerInfo.AirGappedDeployment = submarinerConfig.Spec.AirGappedDeployment
 	brokerInfo.NATEnabled = submarinerConfig.Spec.NATTEnable
 	brokerInfo.LoadBalancerEnabled = submarinerConfig.Spec.LoadBalancerEnable
+	brokerInfo.InsecureBrokerConnection = submarinerConfig.Spec.InsecureBrokerConnection
 
 	if submarinerConfig.Spec.CableDriver != "" {
 		brokerInfo.CableDriver = submarinerConfig.Spec.CableDriver

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
@@ -180,6 +180,7 @@ var _ = Describe("Function Get", func() {
 				Expect(brokerInfo.AirGappedDeployment).To(BeFalse())
 				Expect(brokerInfo.SubmarinerGatewayImage).To(BeEmpty())
 				Expect(brokerInfo.SubmarinerRouteAgentImage).To(BeEmpty())
+				Expect(brokerInfo.InsecureBrokerConnection).To(BeFalse())
 			})
 		})
 

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
@@ -200,12 +200,13 @@ var _ = Describe("Function Get", func() {
 							SubmarinerRouteAgentImagePullSpec:          "quay.io/submariner/submariner-route-agent:10.0.1",
 							SubmarinerNetworkPluginSyncerImagePullSpec: "quay.io/submariner/submariner-networkplugin-syncer:10.0.1",
 						},
-						CableDriver:         "wireguard",
-						IPSecNATTPort:       5678,
-						NATTEnable:          true,
-						LoadBalancerEnable:  true,
-						AirGappedDeployment: true,
-						GlobalCIDR:          "242.1.0.0/16",
+						CableDriver:              "wireguard",
+						IPSecNATTPort:            5678,
+						NATTEnable:               true,
+						LoadBalancerEnable:       true,
+						AirGappedDeployment:      true,
+						InsecureBrokerConnection: true,
+						GlobalCIDR:               "242.1.0.0/16",
 					},
 				}
 			})
@@ -227,6 +228,7 @@ var _ = Describe("Function Get", func() {
 				Expect(brokerInfo.SubmarinerRouteAgentImage).To(Equal(submarinerConfig.Spec.ImagePullSpecs.SubmarinerRouteAgentImagePullSpec))
 				Expect(brokerInfo.SubmarinerNetworkPluginSyncerImage).To(Equal(
 					submarinerConfig.Spec.ImagePullSpecs.SubmarinerNetworkPluginSyncerImagePullSpec))
+				Expect(brokerInfo.InsecureBrokerConnection).To(Equal(submarinerConfig.Spec.InsecureBrokerConnection))
 			})
 
 			It("should return an empty GlobalCIDR as globalnet is disabled", func() {


### PR DESCRIPTION
It can be useful to disable certificate validation when connecting to the broker; Submariner allows this but the corresponding setting isn't exposed in SubmarinerConfig, and thus can't be set (since the settings in SubmarinerConfig overwrite any different settings in the corresponding Submariner CR).

This adds an "InsecureBrokerConnection" flag in SubmarinerConfig.

Signed-off-by: Stephen Kitt <skitt@redhat.com>