### PR TITLE
Drop the version tag from the Submariner CR

### DIFF
--- a/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
@@ -53,4 +53,3 @@ spec:
     {{- end}}
 {{- end}}
   repository: registry.redhat.io/rhacm2
-  version: v0.14.0


### PR DESCRIPTION
The bundle used for Submariner contains the relevant image hashes, so we shouldn't need to override the version with a tag any more. Specifying the tag means that OpenShift's disconnected setup features can't be used; removing the tag should enable them.

Signed-off-by: Stephen Kitt <skitt@redhat.com>