### PR TITLE
Add memory limit for submariner-addon container

### DIFF
--- a/deploy/config/operator/operator.yaml
+++ b/deploy/config/operator/operator.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
+          limits:
+            memory: 270Mi
         env:
           - name: POD_NAME
             valueFrom:

--- a/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
@@ -289,6 +289,8 @@ spec:
                     scheme: HTTPS
                   initialDelaySeconds: 2
                 resources:
+                  limits:
+                    memory: 270Mi
                   requests:
                     cpu: 100m
                     memory: 128Mi


### PR DESCRIPTION
When you specify a Pod, you can optionally specify how much of each resource a container needs. The most common resources to specify are CPU and memory (RAM); there are others.

When you specify the resource request for containers in a Pod, the kube-scheduler uses this information to decide which node to place the Pod on. When you specify a resource limit for a container, the kubelet enforces those limits so that the running container is not allowed to use more of that resource than the limit you set. The kubelet also reserves at least the request amount of that system resource specifically for that container to use.

If the node where a Pod is running has enough of a resource available, it's possible (and allowed) for a container to use more resource than its request for that resource specifies. However, a container is not allowed to use more than its resource limit.

CPU limit is not being set for the addon for reasons described in https://home.robusta.dev/blog/stop-using-cpu-limits/.

Limits and requests for memory are measured in bytes.

This PR sets the limit to 270 mebibytes. This value is double the memory usage found on a hub cluster for submariner-addon pod in open-cluster-management namespace.

Closes: https://github.com/stolostron/submariner-addon/issues/472

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>