### PR TITLE
Update cloud-prepare API

### DIFF
--- a/pkg/cloud/aws/aws.go
+++ b/pkg/cloud/aws/aws.go
@@ -119,10 +119,8 @@ func (a *awsProvider) PrepareSubmarinerClusterEnv() error {
 	}, a.reporter); err != nil {
 		return err
 	}
-	if err := a.cloudPrepare.PrepareForSubmariner(cpapi.PrepareForSubmarinerInput{
-		InternalPorts: []cpapi.PortSpec{
-			{Port: constants.SubmarinerRoutePort, Protocol: "udp"},
-		},
+	if err := a.cloudPrepare.OpenPorts([]cpapi.PortSpec{
+		{Port: constants.SubmarinerRoutePort, Protocol: "udp"},
 	}, a.reporter); err != nil {
 		return err
 	}
@@ -138,7 +136,7 @@ func (a *awsProvider) CleanUpSubmarinerClusterEnv() error {
 		return err
 	}
 
-	if err := a.cloudPrepare.CleanupAfterSubmariner(a.reporter); err != nil {
+	if err := a.cloudPrepare.ClosePorts(a.reporter); err != nil {
 		return err
 	}
 

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -132,12 +132,9 @@ func (r *azureProvider) PrepareSubmarinerClusterEnv() error {
 		return err
 	}
 
-	input := api.PrepareForSubmarinerInput{
-		InternalPorts: []api.PortSpec{
-			{Port: constants.SubmarinerRoutePort, Protocol: "udp"},
-		},
-	}
-	err := r.cloudPrepare.PrepareForSubmariner(input, r.reporter)
+	err := r.cloudPrepare.OpenPorts([]api.PortSpec{
+		{Port: constants.SubmarinerRoutePort, Protocol: "udp"},
+	}, r.reporter)
 	if err != nil {
 		return err
 	}
@@ -155,7 +152,7 @@ func (r azureProvider) CleanUpSubmarinerClusterEnv() error {
 		return err
 	}
 
-	err = r.cloudPrepare.CleanupAfterSubmariner(r.reporter)
+	err = r.cloudPrepare.ClosePorts(r.reporter)
 	if err != nil {
 		return err
 	}

--- a/pkg/cloud/gcp/gcp.go
+++ b/pkg/cloud/gcp/gcp.go
@@ -125,12 +125,9 @@ func (g *gcpProvider) PrepareSubmarinerClusterEnv() error {
 		return err
 	}
 
-	input := api.PrepareForSubmarinerInput{
-		InternalPorts: []api.PortSpec{
-			{Port: constants.SubmarinerRoutePort, Protocol: "udp"},
-		},
-	}
-	err := g.cloudPrepare.PrepareForSubmariner(input, g.reporter)
+	err := g.cloudPrepare.OpenPorts([]api.PortSpec{
+		{Port: constants.SubmarinerRoutePort, Protocol: "udp"},
+	}, g.reporter)
 	if err != nil {
 		return err
 	}
@@ -147,7 +144,7 @@ func (g *gcpProvider) CleanUpSubmarinerClusterEnv() error {
 		return err
 	}
 
-	err = g.cloudPrepare.CleanupAfterSubmariner(g.reporter)
+	err = g.cloudPrepare.ClosePorts(g.reporter)
 	if err != nil {
 		return err
 	}

--- a/pkg/cloud/rhos/rhos.go
+++ b/pkg/cloud/rhos/rhos.go
@@ -126,12 +126,9 @@ func (r *rhosProvider) PrepareSubmarinerClusterEnv() error {
 		return err
 	}
 
-	input := api.PrepareForSubmarinerInput{
-		InternalPorts: []api.PortSpec{
-			{Port: constants.SubmarinerRoutePort, Protocol: "udp"},
-		},
-	}
-	err := r.cloudPrepare.PrepareForSubmariner(input, r.reporter)
+	err := r.cloudPrepare.OpenPorts([]api.PortSpec{
+		{Port: constants.SubmarinerRoutePort, Protocol: "udp"},
+	}, r.reporter)
 	if err != nil {
 		return err
 	}
@@ -149,7 +146,7 @@ func (r rhosProvider) CleanUpSubmarinerClusterEnv() error {
 		return err
 	}
 
-	err = r.cloudPrepare.CleanupAfterSubmariner(r.reporter)
+	err = r.cloudPrepare.ClosePorts(r.reporter)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Following [1] update the API to consume the new function names.

[1] https://github.com/submariner-io/cloud-prepare/pull/571

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>