### PR TITLE
Fix the default GW instance type for Submariner GW

### DIFF
--- a/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -98,8 +98,8 @@ spec:
                     description: RHOS represents the configuration for Redhat Openstack Platform. If the platform of managed cluster is not Redhat Openstack Platform, this field will be ignored.
                     properties:
                       instanceType:
-                        default: PnTAE.CPU_16_Memory_32768_Disk_80
-                        description: InstanceType represents the Redhat Openstack instance type of the gateway node that will be created on the managed cluster. The default value is `PnTAE.CPU_16_Memory_32768_Disk_80`.
+                        default: PnTAE.CPU_4_Memory_8192_Disk_50
+                        description: InstanceType represents the Redhat Openstack instance type of the gateway node that will be created on the managed cluster. The default value is `PnTAE.CPU_4_Memory_8192_Disk_50`.
                         type: string
                     type: object
                 type: object

--- a/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -78,8 +78,8 @@ spec:
                     description: Azure represents the configuration for Azure Cloud Platform. If the platform of managed cluster is not Azure Cloud Platform, this field will be ignored.
                     properties:
                       instanceType:
-                        default: Standard_D4s_v3
-                        description: InstanceType represents the Azure Cloud Platform instance type of the gateway node that will be created on the managed cluster. The default value is `Standard_D4s_v3`.
+                        default: Standard_F4s_v2
+                        description: InstanceType represents the Azure Cloud Platform instance type of the gateway node that will be created on the managed cluster. The default value is `Standard_F4s_v2`.
                         type: string
                     type: object
                   gateways:

--- a/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -96,8 +96,8 @@ spec:
                     description: RHOS represents the configuration for Redhat Openstack Platform. If the platform of managed cluster is not Redhat Openstack Platform, this field will be ignored.
                     properties:
                       instanceType:
-                        default: PnTAE.CPU_16_Memory_32768_Disk_80
-                        description: InstanceType represents the Redhat Openstack instance type of the gateway node that will be created on the managed cluster. The default value is `PnTAE.CPU_16_Memory_32768_Disk_80`.
+                        default: PnTAE.CPU_4_Memory_8192_Disk_50
+                        description: InstanceType represents the Redhat Openstack instance type of the gateway node that will be created on the managed cluster. The default value is `PnTAE.CPU_4_Memory_8192_Disk_50`.
                         type: string
                     type: object
                 type: object

--- a/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -76,8 +76,8 @@ spec:
                     description: Azure represents the configuration for Azure Cloud Platform. If the platform of managed cluster is not Azure Cloud Platform, this field will be ignored.
                     properties:
                       instanceType:
-                        default: Standard_D4s_v3
-                        description: InstanceType represents the Azure Cloud Platform instance type of the gateway node that will be created on the managed cluster. The default value is `Standard_D4s_v3`.
+                        default: Standard_F4s_v2
+                        description: InstanceType represents the Azure Cloud Platform instance type of the gateway node that will be created on the managed cluster. The default value is `Standard_F4s_v2`.
                         type: string
                     type: object
                   gateways:

--- a/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
+++ b/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
@@ -98,8 +98,8 @@ spec:
                     description: RHOS represents the configuration for Redhat Openstack Platform. If the platform of managed cluster is not Redhat Openstack Platform, this field will be ignored.
                     properties:
                       instanceType:
-                        default: PnTAE.CPU_16_Memory_32768_Disk_80
-                        description: InstanceType represents the Redhat Openstack instance type of the gateway node that will be created on the managed cluster. The default value is `PnTAE.CPU_16_Memory_32768_Disk_80`.
+                        default: PnTAE.CPU_4_Memory_8192_Disk_50
+                        description: InstanceType represents the Redhat Openstack instance type of the gateway node that will be created on the managed cluster. The default value is `PnTAE.CPU_4_Memory_8192_Disk_50`.
                         type: string
                     type: object
                 type: object

--- a/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
+++ b/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
@@ -78,8 +78,8 @@ spec:
                     description: Azure represents the configuration for Azure Cloud Platform. If the platform of managed cluster is not Azure Cloud Platform, this field will be ignored.
                     properties:
                       instanceType:
-                        default: Standard_D4s_v3
-                        description: InstanceType represents the Azure Cloud Platform instance type of the gateway node that will be created on the managed cluster. The default value is `Standard_D4s_v3`.
+                        default: Standard_F4s_v2
+                        description: InstanceType represents the Azure Cloud Platform instance type of the gateway node that will be created on the managed cluster. The default value is `Standard_F4s_v2`.
                         type: string
                     type: object
                   gateways:

--- a/pkg/apis/submarinerconfig/v1alpha1/types.go
+++ b/pkg/apis/submarinerconfig/v1alpha1/types.go
@@ -217,9 +217,9 @@ type RHOS struct {
 type Azure struct {
 	// InstanceType represents the Azure Cloud Platform instance type of the gateway node that will be
 	// created on the managed cluster.
-	// The default value is `Standard_D4s_v3`.
+	// The default value is `Standard_F4s_v2`.
 	// +optional
-	// +kubebuilder:default=Standard_D4s_v3
+	// +kubebuilder:default=Standard_F4s_v2
 	InstanceType string `json:"instanceType,omitempty"`
 }
 

--- a/pkg/apis/submarinerconfig/v1alpha1/types.go
+++ b/pkg/apis/submarinerconfig/v1alpha1/types.go
@@ -208,9 +208,9 @@ type GCP struct {
 type RHOS struct {
 	// InstanceType represents the Redhat Openstack instance type of the gateway node that will be
 	// created on the managed cluster.
-	// The default value is `PnTAE.CPU_16_Memory_32768_Disk_80`.
+	// The default value is `PnTAE.CPU_4_Memory_8192_Disk_50`.
 	// +optional
-	// +kubebuilder:default=PnTAE.CPU_16_Memory_32768_Disk_80
+	// +kubebuilder:default=PnTAE.CPU_4_Memory_8192_Disk_50
 	InstanceType string `json:"instanceType,omitempty"`
 }
 

--- a/pkg/apis/submarinerconfig/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/pkg/apis/submarinerconfig/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -20,7 +20,7 @@ func (AWS) SwaggerDoc() map[string]string {
 }
 
 var map_Azure = map[string]string{
-	"instanceType": "InstanceType represents the Azure Cloud Platform instance type of the gateway node that will be created on the managed cluster. The default value is `Standard_D4s_v3`.",
+	"instanceType": "InstanceType represents the Azure Cloud Platform instance type of the gateway node that will be created on the managed cluster. The default value is `Standard_F4s_v2`.",
 }
 
 func (Azure) SwaggerDoc() map[string]string {

--- a/pkg/apis/submarinerconfig/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/pkg/apis/submarinerconfig/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -62,7 +62,7 @@ func (ManagedClusterInfo) SwaggerDoc() map[string]string {
 }
 
 var map_RHOS = map[string]string{
-	"instanceType": "InstanceType represents the Redhat Openstack instance type of the gateway node that will be created on the managed cluster. The default value is `PnTAE.CPU_16_Memory_32768_Disk_80`.",
+	"instanceType": "InstanceType represents the Redhat Openstack instance type of the gateway node that will be created on the managed cluster. The default value is `PnTAE.CPU_4_Memory_8192_Disk_50`.",
 }
 
 func (RHOS) SwaggerDoc() map[string]string {


### PR DESCRIPTION
This PR updates the default Submariner Gateway instance type for Azure/RHOS clusters to the one that is actually deployed.