### PR TITLE
Reduce the frequency of dependabot runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,17 @@ updates:
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: daily
+      interval: monthly
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 5
   - package-ecosystem: gomod
     target-branch: "release-2.5"
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 5
     ignore:
       # K8s and operator SDK, we need to handle these manually
@@ -31,7 +31,7 @@ updates:
     target-branch: "release-2.6"
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 5
     ignore:
       # K8s and operator SDK, we need to handle these manually
@@ -48,7 +48,7 @@ updates:
     target-branch: "release-2.7"
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 5
     ignore:
       # K8s and operator SDK, we need to handle these manually


### PR DESCRIPTION
This matches the rest of the Submariner projects: weekly for Go dependencies, monthly for GHAs.