### PR TITLE
Ignore dependabot bumps for transitive k8s.io

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,13 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 5
+    ignore:
+      # Kept in sync k8s.io/apiextensions-apiserver
+      - dependency-name: k8s.io/api
+      - dependency-name: k8s.io/apimachinery
+      - dependency-name: k8s.io/client-go
+      - dependency-name: k8s.io/code-generator
+      - dependency-name: k8s.io/component-base
   - package-ecosystem: gomod
     target-branch: "release-2.5"
     directory: "/"


### PR DESCRIPTION
Bumping k8s.io/apiextensions-apiserver bumps all the rest of our k8s.io dependencies, instruct dependabot to ignore the latter.