### PR TITLE
Fix the location of submver

### DIFF
--- a/hack/update-submariner.sh
+++ b/hack/update-submariner.sh
@@ -13,7 +13,7 @@ for project in admiral cloud-prepare submariner submariner-operator; do
     go get github.com/submariner-io/${project}@$1
 done
 
-sed -i "s/submver=.*$/submver=${1#v}/" scripts/deploy.sh
+sed -i "s/submver=.*$/submver=${1#v}/" scripts/vars.sh
 
 # Downstream builds track the main version without - suffixes
 sed -i "s/version: .*$/version: ${1%%-*}/" pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml

--- a/scripts/vars.sh
+++ b/scripts/vars.sh
@@ -1,3 +1,3 @@
 k8s_version="v1.23.4"
 submrepo="quay.io/submariner"
-submver="0.14.1"
+submver=0.15.0-m4


### PR DESCRIPTION
The submver variable, used in test deployments (scripts/deploy.sh), has moved to scripts/vars.sh, but hack/update-submariner.sh wasn't changed to follow suit. This addresses that, and bumps submver to 0.15.0-m4.