### PR TITLE
Extract submver from dependencies

### DIFF
--- a/hack/update-submariner.sh
+++ b/hack/update-submariner.sh
@@ -13,10 +13,5 @@ for project in admiral cloud-prepare submariner submariner-operator; do
     go get github.com/submariner-io/${project}@$1
 done
 
-sed -i "s/submver=.*$/submver=${1#v}/" scripts/vars.sh
-
-# Downstream builds track the main version without - suffixes
-sed -i "s/version: .*$/version: ${1%%-*}/" pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
-
 go mod tidy
 go mod vendor

--- a/scripts/vars.sh
+++ b/scripts/vars.sh
@@ -1,3 +1,3 @@
 k8s_version="v1.23.4"
 submrepo="quay.io/submariner"
-submver=0.14.2
+submver="$(go list -m github.com/submariner-io/submariner | cut -d\  -f2 | cut -c2-)"


### PR DESCRIPTION
Instead of updating submver manually, use whatever is specified as the Submariner dependency. This avoids having to update a variable every time Submariner is released, which means we can rely on dependabot to take care of everything for us.

While we're at it, drop the Submariner CR update; it no longer specifies the version to use.

Signed-off-by: Stephen Kitt <skitt@redhat.com>
(cherry picked from commit 6c07797fab23def351f4f2acd6dca3494816b44f)