### PR TITLE
Set default channel for submariner

### DIFF
--- a/pkg/hub/submarinerbrokerinfo/brokerinfo.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo.go
@@ -30,6 +30,7 @@ const (
 	catalogName                   = "submariner"
 	defaultCatalogSource          = "redhat-operators"
 	defaultCatalogSourceNamespace = "openshift-marketplace"
+	defaultCatalogChannel         = "stable-0.13"
 	defaultCableDriver            = "libreswan"
 	defaultInstallationNamespace  = "open-cluster-management-agent-addon"
 	brokerAPIServer               = "BROKER_API_SERVER"
@@ -103,6 +104,7 @@ func Get(
 		CatalogName:            catalogName,
 		CatalogSource:          defaultCatalogSource,
 		CatalogSourceNamespace: defaultCatalogSourceNamespace,
+		CatalogChannel:         defaultCatalogChannel,
 		InstallationNamespace:  defaultInstallationNamespace,
 		InstallPlanApproval:    "Automatic",
 	}

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
@@ -161,7 +161,7 @@ var _ = Describe("Function Get", func() {
 		When("no SubmarinerConfig is provided", func() {
 			It("should return the defaults", func() {
 				Expect(brokerInfo.CableDriver).To(Equal("libreswan"))
-				Expect(brokerInfo.CatalogChannel).To(BeEmpty())
+				Expect(brokerInfo.CatalogChannel).To(Equal("stable-0.13"))
 				Expect(brokerInfo.CatalogName).To(Equal("submariner"))
 				Expect(brokerInfo.CatalogSource).To(Equal("redhat-operators"))
 				Expect(brokerInfo.CatalogSourceNamespace).To(Equal("openshift-marketplace"))


### PR DESCRIPTION
Set default channel for submariner subscription config to stable-0.13 for ACM 2.6