### PR TITLE
Set default channel for submariner

### DIFF
--- a/pkg/hub/submarinerbrokerinfo/brokerinfo.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo.go
@@ -31,6 +31,7 @@ const (
 	catalogName                   = "submariner"
 	defaultCatalogSource          = "redhat-operators"
 	defaultCatalogSourceNamespace = "openshift-marketplace"
+	defaultCatalogChannel         = "stable-0.14"
 	defaultCableDriver            = "libreswan"
 	defaultInstallationNamespace  = "open-cluster-management-agent-addon"
 	brokerAPIServer               = "BROKER_API_SERVER"
@@ -107,6 +108,7 @@ func Get(
 		CatalogName:            catalogName,
 		CatalogSource:          defaultCatalogSource,
 		CatalogSourceNamespace: defaultCatalogSourceNamespace,
+		CatalogChannel:         defaultCatalogChannel,
 		InstallationNamespace:  defaultInstallationNamespace,
 		InstallPlanApproval:    "Automatic",
 	}

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Function Get", func() {
 		When("no SubmarinerConfig is provided", func() {
 			It("should return the defaults", func() {
 				Expect(brokerInfo.CableDriver).To(Equal("libreswan"))
-				Expect(brokerInfo.CatalogChannel).To(BeEmpty())
+				Expect(brokerInfo.CatalogChannel).To(Equal("stable-0.14"))
 				Expect(brokerInfo.CatalogName).To(Equal("submariner"))
 				Expect(brokerInfo.CatalogSource).To(Equal("redhat-operators"))
 				Expect(brokerInfo.CatalogSourceNamespace).To(Equal("openshift-marketplace"))


### PR DESCRIPTION
Set default channel for submariner subscription config to stable-0.14 for ACM 2.7