### PR TITLE
Add rbac for AddonDeploymentConfig

### DIFF
--- a/deploy/config/rbac/cluster_role.yaml
+++ b/deploy/config/rbac/cluster_role.yaml
@@ -57,6 +57,9 @@ rules:
   verbs: ["update", "patch"]
 # Allow submariner-addon hub controller to run with addon-framwork
 - apiGroups: ["addon.open-cluster-management.io"]
+  resources: ["addondeploymentconfigs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["addon.open-cluster-management.io"]
   resources: ["clustermanagementaddons"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["addon.open-cluster-management.io"]

--- a/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
@@ -188,6 +188,14 @@ spec:
         - apiGroups:
           - addon.open-cluster-management.io
           resources:
+          - addondeploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - addon.open-cluster-management.io
+          resources:
           - clustermanagementaddons
           verbs:
           - get


### PR DESCRIPTION
Add get, list and watch permissions for AddonDeploymentConfig so submariner addon can track changes to it.

Refer https://github.com/submariner-io/submariner-operator/pull/2530