### PR TITLE
Create submariner ClusterManagementAddon

### DIFF
--- a/deploy/config/operator/clustermanagementaddon.yaml
+++ b/deploy/config/operator/clustermanagementaddon.yaml
@@ -1,0 +1,11 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: submariner
+spec:
+  addOnMeta:
+    displayName: "Submariner Addon"
+    description: "Submariner Addon for MultiCluster connectivity"
+  supportedConfigs:
+  - group: addon.open-cluster-management.io
+    resource: addondeploymentconfigs

--- a/deploy/config/operator/kustomization.yaml
+++ b/deploy/config/operator/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
   - namespace.yaml
+  - clustermanagementaddon.yaml
   - service_account.yaml
   - operator.yaml


### PR DESCRIPTION
Create submariner ClusterManagementAddon when deploying submariner addon on Hub cluster. This is required to configure default submariner AddonDeploymentConfig for all ManagedClusters which have submariner addon installed.