### PR TITLE
Ensure ManagedCluster finalizer is removed even if the add-on does not exist

### DIFF
--- a/pkg/hub/submarineragent/controller.go
+++ b/pkg/hub/submarineragent/controller.go
@@ -261,6 +261,35 @@ func (c *submarinerAgentController) syncManagedCluster(
 	managedCluster *clusterv1.ManagedCluster,
 	config *configv1alpha1.SubmarinerConfig,
 ) error {
+	// managed cluster is deleting, we remove its related resources
+	if !managedCluster.DeletionTimestamp.IsZero() {
+		logger.Infof("ManagedCluster %q is deleting", managedCluster.Name)
+
+		return c.cleanUpSubmarinerAgent(ctx, managedCluster)
+	}
+
+	clusterSetName, existed := managedCluster.Labels[clusterv1beta2.ClusterSetLabel]
+	if !existed {
+		// the cluster does not have the clusterset label, try to clean up the submariner agent
+		logger.Infof("ManagedCluster %q is missing the cluster set label", managedCluster.Name)
+
+		return c.cleanUpSubmarinerAgent(ctx, managedCluster)
+	}
+
+	// find the clustersets that contains this managed cluster
+	_, err := c.clusterSetLister.Get(clusterSetName)
+
+	switch {
+	case apierrors.IsNotFound(err):
+		// if one cluster has clusterset label, but the clusterset is not found, it could have been deleted
+		// try to clean up the submariner agent
+		logger.Infof("ManagedClusterSet %q not found", clusterSetName)
+
+		return c.cleanUpSubmarinerAgent(ctx, managedCluster)
+	case err != nil:
+		return err
+	}
+
 	// find the submariner-addon on the managed cluster namespace
 	addOn, err := c.addOnLister.ManagedClusterAddOns(managedCluster.Name).Get(constants.SubmarinerAddOnName)
 
@@ -272,40 +301,11 @@ func (c *submarinerAgentController) syncManagedCluster(
 		return err
 	}
 
-	// managed cluster is deleting, we remove its related resources
-	if !managedCluster.DeletionTimestamp.IsZero() {
-		logger.Infof("ManagedCluster %q is deleting", managedCluster.Name)
-
-		return c.cleanUpSubmarinerAgent(ctx, managedCluster, addOn)
-	}
-
-	clusterSetName, existed := managedCluster.Labels[clusterv1beta2.ClusterSetLabel]
-	if !existed {
-		// the cluster does not have the clusterset label, try to clean up the submariner agent
-		logger.Infof("ManagedCluster %q is missing the cluster set label", managedCluster.Name)
-
-		return c.cleanUpSubmarinerAgent(ctx, managedCluster, addOn)
-	}
-
-	// find the clustersets that contains this managed cluster
-	_, err = c.clusterSetLister.Get(clusterSetName)
-
-	switch {
-	case apierrors.IsNotFound(err):
-		// if one cluster has clusterset label, but the clusterset is not found, it could have been deleted
-		// try to clean up the submariner agent
-		logger.Infof("ManagedClusterSet %q not found", clusterSetName)
-
-		return c.cleanUpSubmarinerAgent(ctx, managedCluster, addOn)
-	case err != nil:
-		return err
-	}
-
 	// submariner-addon is deleting, we remove its related resources
 	if !addOn.DeletionTimestamp.IsZero() {
 		logger.Infof("ManagedClusterAddOn %q in cluster %q is deleting", addOn.Name, addOn.Namespace)
 
-		return c.cleanUpSubmarinerAgent(ctx, managedCluster, addOn)
+		return c.cleanUpSubmarinerAgent(ctx, managedCluster)
 	}
 
 	// add a submariner agent finalizer to a managed cluster
@@ -333,9 +333,7 @@ func (c *submarinerAgentController) syncManagedCluster(
 }
 
 // clean up the submariner agent from this managedCluster.
-func (c *submarinerAgentController) cleanUpSubmarinerAgent(ctx context.Context, managedCluster *clusterv1.ManagedCluster,
-	addOn *addonv1alpha1.ManagedClusterAddOn,
-) error {
+func (c *submarinerAgentController) cleanUpSubmarinerAgent(ctx context.Context, managedCluster *clusterv1.ManagedCluster) error {
 	submarinerManifestWork, err := c.manifestWorkLister.ManifestWorks(managedCluster.Name).Get(SubmarinerCRManifestWorkName)
 
 	switch {
@@ -348,6 +346,7 @@ func (c *submarinerAgentController) cleanUpSubmarinerAgent(ctx context.Context, 
 	case submarinerManifestWork.DeletionTimestamp.IsZero():
 		return c.deleteManifestWork(ctx, SubmarinerCRManifestWorkName, managedCluster.Name)
 	default:
+		logger.Infof("ManifestWork %q is still deleting", SubmarinerCRManifestWorkName)
 		return nil
 	}
 
@@ -361,8 +360,13 @@ func (c *submarinerAgentController) cleanUpSubmarinerAgent(ctx context.Context, 
 		return err
 	}
 
-	return finalizer.Remove(ctx, resource.ForAddon(c.addOnClient.AddonV1alpha1().ManagedClusterAddOns(managedCluster.Name)),
-		addOn, AddOnFinalizer)
+	addOn, err := c.addOnLister.ManagedClusterAddOns(managedCluster.Name).Get(constants.SubmarinerAddOnName)
+	if err == nil {
+		return finalizer.Remove(ctx, resource.ForAddon(c.addOnClient.AddonV1alpha1().ManagedClusterAddOns(managedCluster.Name)),
+			addOn, AddOnFinalizer)
+	}
+
+	return nil
 }
 
 func (c *submarinerAgentController) deploySubmarinerAgent(


### PR DESCRIPTION
The `submarinerAgentController` assumes the submariner `ManagedClusterAddOn` exists when cleaning up on `ManagedCluster` deletion. However, if it doesn't, cleanup never completes and the finalizer is not removed from the `ManagedCluster`. This shouldn't normally happen since the controller also adds a finalizer to the `ManagedClusterAddOn` but this scenario was observed in a real installation (see https://issues.redhat.com/browse/ACM-5381).