### PR TITLE
Add backup label to globalnet configmap

### DIFF
--- a/pkg/hub/submarineragent/controller.go
+++ b/pkg/hub/submarineragent/controller.go
@@ -63,7 +63,8 @@ const (
 	submarinerCRFile              = "manifests/operator/submariner.io-submariners-cr.yaml"
 	BrokerCfgApplied              = "SubmarinerBrokerConfigApplied"
 	BrokerObjectName              = "submariner-broker"
-	BackupLabel                   = "cluster.open-cluster-management.io/backup"
+	BackupLabelKey                = "cluster.open-cluster-management.io/backup"
+	BackupLabelValue              = "submariner"
 	addonDeploymentConfigResource = "addondeploymentconfigs"
 	addonDeploymentConfigGroup    = "addon.open-cluster-management.io"
 )
@@ -663,7 +664,8 @@ func (c *submarinerAgentController) createGNConfigMapIfNecessary(ctx context.Con
 	}
 
 	if gnCmErr == nil {
-		return nil
+		// This should handle upgrade from a version that didn't add the label
+		return c.updateBackupLabelOnGnConfigMap(ctx, brokerNamespace)
 	}
 
 	// globalnetConfig is missing in the broker-namespace, try creating it from submariner-broker object.
@@ -687,12 +689,43 @@ func (c *submarinerAgentController) createGNConfigMapIfNecessary(ctx context.Con
 		logger.Infof("Globalnet is disabled in the managedClusterSet namespace %q", brokerNamespace)
 	}
 
-	if err := globalnet.CreateConfigMap(ctx, c.controllerClient, brokerObj.Spec.GlobalnetEnabled,
-		brokerObj.Spec.GlobalnetCIDRRange, brokerObj.Spec.DefaultGlobalnetClusterSize, brokerNamespace); err != nil {
-		return errors.Wrapf(err, "error creating globalnet configmap on Broker")
+	configMap, err := globalnet.NewGlobalnetConfigMap(brokerObj.Spec.GlobalnetEnabled,
+		brokerObj.Spec.GlobalnetCIDRRange, brokerObj.Spec.DefaultGlobalnetClusterSize, brokerNamespace)
+	if err == nil {
+		configMap.Labels[BackupLabelKey] = BackupLabelValue
+		err = c.controllerClient.Create(ctx, configMap)
 	}
 
-	return nil
+	return errors.Wrapf(err, "error creating globalnet configmap on Broker")
+}
+
+func (c *submarinerAgentController) updateBackupLabelOnGnConfigMap(ctx context.Context, namespace string) error {
+	return errors.Wrapf(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		gnConfigMap, err := globalnet.GetConfigMap(ctx, c.controllerClient, namespace)
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		oldLabels := gnConfigMap.GetLabels()
+		if oldLabels == nil {
+			oldLabels = make(map[string]string)
+		}
+
+		if _, ok := oldLabels[BackupLabelKey]; !ok {
+			oldLabels[BackupLabelKey] = BackupLabelValue
+			gnConfigMap.SetLabels(oldLabels)
+			err = c.controllerClient.Update(ctx, gnConfigMap)
+			if err == nil {
+				logger.Infof("Successfully added backup label to globalnet configmap in %q", namespace)
+			}
+		}
+
+		return err
+	}), "error adding backup label to globalnet configmap in %q", namespace)
 }
 
 func (c *submarinerAgentController) getBrokerObject(ctx context.Context, brokerNamespace string) (*submarinerv1a1.Broker, error) {
@@ -727,8 +760,8 @@ func (c *submarinerAgentController) updateBackupLabelOnBroker(ctx context.Contex
 		if existingLabels == nil {
 			existingLabels = make(map[string]string)
 		}
-		if _, ok := existingLabels[BackupLabel]; !ok {
-			existingLabels[BackupLabel] = "submariner"
+		if _, ok := existingLabels[BackupLabelKey]; !ok {
+			existingLabels[BackupLabelKey] = BackupLabelValue
 			existing.SetLabels(existingLabels)
 			_, err = brokerClient.Update(ctx, existing, metav1.UpdateOptions{})
 			if err == nil {

--- a/pkg/hub/submarineragent/controller_test.go
+++ b/pkg/hub/submarineragent/controller_test.go
@@ -638,7 +638,7 @@ func (t *testDriver) awaitBackupLabelOnBroker() {
 		if labels == nil {
 			return false
 		}
-		_, ok := labels[submarineragent.BackupLabel]
+		_, ok := labels[submarineragent.BackupLabelKey]
 
 		return ok
 	}).Should(BeTrue(), "Backup label missing on submariner-broker")


### PR DESCRIPTION
When creating globalnet configmap, add backup label to it so that it is backed up to new hub. Without this label, addon agent will reallocate global cidrs to managedclusters on restore. If clusters get new CIDRs allocated, it will break connectivity.