### PR TITLE
Reduce globalnet logging in submarinerAgentController

### DIFF
--- a/pkg/hub/submarinerbrokerinfo/brokerinfo.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo.go
@@ -179,14 +179,14 @@ func applyGlobalnetConfig(ctx context.Context, controllerClient controllerclient
 			netconfig.GlobalCIDR = submarinerConfig.Spec.GlobalCIDR
 		}
 
-		status := reporter.Klog()
+		status := reporter.Silent()
 		err = globalnet.AllocateAndUpdateGlobalCIDRConfigMap(ctx, controllerClient, brokerNamespace, &netconfig, status)
 		if err != nil {
 			logger.Errorf(err, "Unable to allocate globalCIDR to cluster %q", clusterName)
 			return err
 		}
 
-		logger.Infof("Allocated globalCIDR %q for Cluster %q", netconfig.GlobalCIDR, clusterName)
+		logger.V(log.DEBUG).Infof("Allocated globalCIDR %q for Cluster %q", netconfig.GlobalCIDR, clusterName)
 		brokerInfo.GlobalCIDR = netconfig.GlobalCIDR
 	}
 


### PR DESCRIPTION
The following log statements occur repeatedly for every update and create excessive noise:

```
I0508 08:18:19.181025       1 klog.go:30] Retrieving Globalnet information from the Broker
I0508 08:18:19.182901       1 klog.go:30] Validating Globalnet configuration
I0508 08:18:19.182916       1 klog.go:30] Assigning Globalnet IPs
I0508 08:18:19.182920       1 klog.go:37] Using pre-configured global CIDR 242.0.0.0/16
2023-05-08T08:18:19.182Z INF ..rinfo/brokerinfo.go:189 BrokerInfo           Allocated globalCIDR "242.0.0.0/16" for Cluster "mbabushk-gcp"
```

All but the last emanate from the **submariner-operator** code via the supplied status `reporter.Interface`. This trace logging doesn't really add much value here so use the `Silent` reporter to suppress the output.

For the last one, increase the log level to DEBUG.