### PR TITLE
Reuse code for setting the backup label in submarinerAgentController

### DIFF
--- a/pkg/hub/manager.go
+++ b/pkg/hub/manager.go
@@ -15,14 +15,17 @@ import (
 	"github.com/stolostron/submariner-addon/pkg/hub/submarineragent"
 	"github.com/stolostron/submariner-addon/pkg/hub/submarinerbroker"
 	"github.com/stolostron/submariner-addon/pkg/resource"
+	submarinerv1alpha1 "github.com/submariner-io/submariner-operator/api/v1alpha1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/dynamic"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
@@ -86,6 +89,8 @@ func (o *AddOnOptions) Complete(ctx context.Context, kubeClient kubernetes.Inter
 
 // RunControllerManager starts the controllers on hub to manage submariner deployment.
 func (o *AddOnOptions) RunControllerManager(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
+	utilruntime.Must(submarinerv1alpha1.AddToScheme(scheme.Scheme))
+
 	kubeClient, err := kubernetes.NewForConfig(controllerContext.KubeConfig)
 	if err != nil {
 		return err

--- a/pkg/hub/submarineragent/controller_test.go
+++ b/pkg/hub/submarineragent/controller_test.go
@@ -699,11 +699,7 @@ func (t *testDriver) awaitBackupLabelOnBroker() {
 			return false
 		}
 
-		labels := broker.GetLabels()
-		if labels == nil {
-			return false
-		}
-		_, ok := labels[submarineragent.BackupLabelKey]
+		_, ok := broker.Labels[submarineragent.BackupLabelKey]
 
 		return ok
 	}).Should(BeTrue(), "Backup label missing on submariner-broker")

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -13,11 +13,9 @@ import (
 	"github.com/stolostron/submariner-addon/pkg/hub"
 	"github.com/stolostron/submariner-addon/test/util"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
-	suboperatorapi "github.com/submariner-io/submariner-operator/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	addonclientset "open-cluster-management.io/api/client/addon/clientset/versioned"
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
@@ -84,8 +82,6 @@ var _ = BeforeSuite(func() {
 	cfg, err = testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
-
-	Expect(suboperatorapi.AddToScheme(scheme.Scheme)).To(Succeed())
 
 	// prepare clients
 	kubeClient, err = kubernetes.NewForConfig(cfg)


### PR DESCRIPTION
Define a generalized `addBackupLabel` method used for both the `Broker` and **globalnet** `ConfigMap`. To facilitate this, the `controllerClient` is now used for accessing the `Broker` resource instead of the `dynamicClient`.
