### PR TITLE
Align linting with Submariner

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@
 run:
   skip-dirs:
     - pkg/cloud
-  go: 1.17
 linters-settings:
   gocritic:
     enabled-tags:
@@ -10,6 +9,9 @@ linters-settings:
       - opinionated
       - performance
       - style
+    disabled-checks:
+      - ifElseChain
+      - unnamedResult
   gocyclo:
     min-complexity: 15
   govet:
@@ -17,87 +19,102 @@ linters-settings:
       - fieldalignment
   lll:
     line-length: 140
-  nlreturn:
-    block-size: 2
+  wsl:
+    # Separating explicit var declarations by blank lines seems excessive.
+    allow-cuddle-declarations: true
 linters:
   disable-all: true
   enable:
+    - asasalint
     - asciicheck
+    - bidichk
     - bodyclose
+    - containedctx
     - contextcheck
     # - cyclop # This is equivalent to gocyclo
-    - deadcode
+    - decorder
     - depguard
     - dogsled
     - dupl
+    - dupword
     - durationcheck
     - errcheck
-    - errname
+    - errchkjson
     - errorlint
+    - errname
+    # - execinquery # No SQL
     - exhaustive
-    # - exhaustivestruct # Not recommended for general use - meant to be used only for special cases
+    # - exhauststruct # Not recommended for general use - meant to be used only for special cases
     - exportloopref
     # - forbidigo # We don't forbid any statements
-    # - forcetypeassert # Most if not all unchecked type assertions would be the result of a programming
-    #     error so the reasonable recourse would be to panic anyway if checked so this doesn't seem useful.
-    # - funlen # gocyclo is enabled which is generally a better metric than simply LOC
+    # - forcetypeassert # There are many unchecked type assertions that would be the result of a programming error so the
+    #                     reasonable recourse would be to panic anyway if checked so this doesn't seem useful
+    # - funlen # gocyclo is enabled which is generally a better metric than simply LOC.
     - gci
-    # - gochecknoglobal # We don't want to forbid global variable constants
-    # - gochecknoinits # We have valid uses for init functions
+    - ginkgolinter
+    # - gochecknoglobals # We don't want to forbid global variable constants
+    # - gochecknoinits # We use init functions for valid reasons
     - gocognit
     - goconst
     - gocritic
     - gocyclo
-    - godot
-    # - godox # Let's not forbid inline TODOs, FIXMEs et al
     - goerr113
+    - godot
+    # - godox #  Let's not forbid inline TODOs, FIXMEs et al
     - gofmt
     - gofumpt
     # - goheader # We do license header linting another way
     - goimports
-    # - golint # Deprecated since v1.41.0
-    # - gomnd # It doesn't seem useful in general to enforce constants for all numeric value
+    # - gomnd # It doesn't seem useful in general to enforce constants for all numeric values
     # - gomoddirectives # We don't want to forbid the 'replace' directive
     # - gomodguard # We don't block any modules
     # - goprintffuncname # This doesn't seem useful at all
     - gosec
     - gosimple
     - govet
-    # - ifshort # This is a style preference and doesn't seem compelling
-    # - importas # Not supported with our version of golangci-lint
+    - grouper
+    - importas
     - ineffassign
-    # - interfacer # Deprecated since v1.38.0
+    # - interfacebloat # We track complexity elsewhere
+    # - ireturn # The argument to always "Return Concrete Types" doesn't seem compelling. It is perfectly valid to return
+    #             an interface to avoid exposing the entire underlying struct
     - lll
+    - loggercheck
+    - maintidx
     - makezero
-    # - maligned # Deprecated since v1.38.0
     - misspell
     - nakedret
     # - nestif # This calculates cognitive complexity but we're doing that elsewhere
     - nilerr
-    - nlreturn
+    - nilnil
+    # - nlreturn # This is reasonable with a block-size of 2 but setting it above isn't honored
     # - noctx # We don't send HTTP requests
     - nolintlint
-    # - paralleltest # Not relevant for Ginkgo UT
+    # - nonamedreturns # We don't forbid named returns
+    - nosprintfhostport
+    # - paralleltest # Not relevant for Ginkgo UTs
     - prealloc
     - predeclared
-    # - promlinter # Not supported with our version of golangci-lint
+    - promlinter
+    - reassign
     - revive
     # - rowserrcheck # We don't use SQL
-    # - scopelint # Deprecated since v1.39.0
     # - sqlclosecheck # We don't use SQL
     - staticcheck
-    - structcheck
     - stylecheck
     # - tagliatelle # Inconsistent with stylecheck and not as good
+    # - tenv # Not relevant for our Ginkgo UTs
+    - testableexamples
     - testpackage
     # - thelper # Not relevant for our Ginkgo UTs
-    - tparallel
+    # - tparallel # Not relevant for our Ginkgo UTs
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
-    # - wastedassign # Not supported with our version of golangci-lint
+    - usestdlibvars
+    # - varnamelen # It doesn't seem necessary to enforce a minimum variable name length
+    - wastedassign
     - whitespace
     # - wrapcheck # Fix and enable
     - wsl
@@ -120,14 +137,14 @@ issues:
         - wsl
       text: "only one cuddle assignment allowed before range statement"
 
-    # Allow dot imports for gomega
+    # Allow dot-imports for Gomega BDD directives per idiomatic Gomega
     - linters:
         - revive
         - stylecheck
       text: "dot imports"
       source: "gomega"
 
-    # Allow dot imports for ginkgo
+    # Allow dot-imports for Ginkgo BDD directives per idiomatic Ginkgo
     - linters:
         - revive
         - stylecheck

--- a/Makefile
+++ b/Makefile
@@ -139,12 +139,18 @@ else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
+GOLANGCI_LINT_VERSION=v1.52.2
+GOLANGCI_LINT?=$(PERMANENT_TMP_GOPATH)/bin/golangci-lint
+
+$(GOLANGCI_LINT):
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(PERMANENT_TMP_GOPATH)/bin $(GOLANGCI_LINT_VERSION)
+
 # [golangci-lint] validates Go code in the project
-golangci-lint: vendor
-	golangci-lint version
-	golangci-lint linters
-	golangci-lint cache clean
-	golangci-lint run --timeout 10m
+golangci-lint: vendor | $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT) version
+	$(GOLANGCI_LINT) linters
+	$(GOLANGCI_LINT) cache clean
+	$(GOLANGCI_LINT) run --timeout 10m
 
 vendor: go.mod
 	$(GO) mod download

--- a/pkg/hub/submarineraddonagent/agent.go
+++ b/pkg/hub/submarineraddonagent/agent.go
@@ -197,7 +197,7 @@ func (a *addOnAgent) GetAgentAddonOptions() agent.AgentAddonOptions {
 // 1. if the signer name in csr request is valid.
 // 2. if organization field and commonName field in csr request is valid.
 // 3. if user name in csr is the same as commonName field in csr request.
-func (a *addOnAgent) csrApproveCheck(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn,
+func (a *addOnAgent) csrApproveCheck(cluster *clusterv1.ManagedCluster, _ *addonapiv1alpha1.ManagedClusterAddOn,
 	csr *certificatesv1.CertificateSigningRequest,
 ) bool {
 	if csr.Spec.SignerName != certificatesv1.KubeAPIServerClientSignerName {
@@ -275,7 +275,7 @@ func (a *addOnAgent) permissionConfig(cluster *clusterv1.ManagedCluster, _ *addo
 	return operatorhelpers.NewMultiLineAggregate(errs)
 }
 
-// This will set a.hubHost, if empty, to Hub's API url by getting it form local-cluster
+// This will set a.hubHost, if empty, to Hub's API url by getting it form local-cluster.
 // local-cluster will be missing in kind deployments. In ACM deployments there is a race
 // condition between local-cluster and submariner-addon pod creation. So we check for it right
 // before we use it for manifests. This code gets called repeatedly from syncer, so even if

--- a/pkg/spoke/submarineragent/config_controller.go
+++ b/pkg/spoke/submarineragent/config_controller.go
@@ -228,11 +228,7 @@ func (c *submarinerConfigController) syncConfig(ctx context.Context, recorder ev
 		return err
 	}
 
-	if err := c.prepareForSubmariner(ctx, config, recorder); err != nil {
-		return err
-	}
-
-	return nil
+	return c.prepareForSubmariner(ctx, config, recorder)
 }
 
 // skipSyncingUnchangedConfig if last submariner config is known and is equal to the given config.

--- a/pkg/spoke/submarineragent/deployment_controller.go
+++ b/pkg/spoke/submarineragent/deployment_controller.go
@@ -348,7 +348,7 @@ func (c *deploymentStatusController) getSubmariner() (*submarinerv1alpha1.Submar
 	}
 
 	if len(list) == 0 {
-		return nil, nil
+		return nil, nil //nolint:nilnil // No Submariner is not an error
 	}
 
 	unstructuredSubmariner, err := runtime.DefaultUnstructuredConverter.ToUnstructured(list[0])

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -284,7 +284,7 @@ func (r *IntegrationTestEventRecorder) ForComponent(c string) events.Recorder {
 	return &IntegrationTestEventRecorder{component: c}
 }
 
-func (r *IntegrationTestEventRecorder) WithContext(ctx context.Context) events.Recorder {
+func (r *IntegrationTestEventRecorder) WithContext(_ context.Context) events.Recorder {
 	return r
 }
 


### PR DESCRIPTION
This updates the golangci-lint target to install a version of golangci-lint determined by the project, instead of relying on externally-provided images. It updates golangci-lint to v1.52.2 (not the latest, but matching Submariner) and fixes a few issues.