### PR TITLE
Allow Submariner debugging to be enabled

### DIFF
--- a/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -32,6 +32,14 @@ spec:
           spec:
             description: Spec defines the configuration of the Submariner
             properties:
+              Debug:
+                default: false
+                description: Debug enables Submariner debugging (in the logs).
+                type: boolean
+              IPSecDebug:
+                default: false
+                description: IPSecDebug enables IPSec debugging.
+                type: boolean
               IPSecIKEPort:
                 default: 500
                 description: IPSecIKEPort represents IPsec IKE port (default 500).

--- a/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -30,6 +30,14 @@ spec:
           spec:
             description: Spec defines the configuration of the Submariner
             properties:
+              Debug:
+                default: false
+                description: Debug enables Submariner debugging (in the logs).
+                type: boolean
+              IPSecDebug:
+                default: false
+                description: IPSecDebug enables IPSec debugging.
+                type: boolean
               IPSecIKEPort:
                 default: 500
                 description: IPSecIKEPort represents IPsec IKE port (default 500).

--- a/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
+++ b/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
@@ -32,6 +32,14 @@ spec:
           spec:
             description: Spec defines the configuration of the Submariner
             properties:
+              Debug:
+                default: false
+                description: Debug enables Submariner debugging (in the logs).
+                type: boolean
+              IPSecDebug:
+                default: false
+                description: IPSecDebug enables IPSec debugging.
+                type: boolean
               IPSecIKEPort:
                 default: 500
                 description: IPSecIKEPort represents IPsec IKE port (default 500).

--- a/pkg/apis/submarinerconfig/v1alpha1/types.go
+++ b/pkg/apis/submarinerconfig/v1alpha1/types.go
@@ -74,6 +74,16 @@ type SubmarinerConfigSpec struct {
 	// +kubebuilder:default=false
 	InsecureBrokerConnection bool `json:"insecureBrokerConnection"`
 
+	// IPSecDebug enables IPSec debugging.
+	// +optional
+	// +kubebuilder:default=false
+	IPSecDebug bool `json:"IPSecDebug,omitempty"`
+
+	// Debug enables Submariner debugging (in the logs).
+	// +optional
+	// +kubebuilder:default=false
+	Debug bool `json:"Debug,omitempty"`
+
 	// CredentialsSecret is a reference to the secret with a certain cloud platform
 	// credentials, the supported platform includes AWS, GCP, Azure, ROKS and OSD.
 	// The submariner-addon will use these credentials to prepare Submariner cluster

--- a/pkg/apis/submarinerconfig/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/pkg/apis/submarinerconfig/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -100,6 +100,8 @@ var map_SubmarinerConfigSpec = map[string]string{
 	"airGappedDeployment":      "AirGappedDeployment specifies that the cluster is in an air-gapped environment without access to external servers.",
 	"loadBalancerEnable":       "LoadBalancerEnable enables or disables load balancer mode. When enabled, a LoadBalancer is created in the submariner-operator namespace (default false).",
 	"insecureBrokerConnection": "InsecureBrokerConnection disables certificate validation when contacting the broker. This is useful for scenarios where the certificate chain isn't the same everywhere, e.g. with self-signed certificates with a different trust chain in each cluster.",
+	"IPSecDebug":               "IPSecDebug enables IPSec debugging.",
+	"Debug":                    "Debug enables Submariner debugging (in the logs).",
 	"credentialsSecret":        "CredentialsSecret is a reference to the secret with a certain cloud platform credentials, the supported platform includes AWS, GCP, Azure, ROKS and OSD. The submariner-addon will use these credentials to prepare Submariner cluster environment. If the submariner cluster environment requires submariner-addon preparation, this field should be specified.",
 	"subscriptionConfig":       "SubscriptionConfig represents a Submariner subscription. SubscriptionConfig can be used to customize the Submariner subscription.",
 	"imagePullSpecs":           "ImagePullSpecs represents the desired images of submariner components installed on the managed cluster. If not specified, the default submariner images that was defined by submariner operator will be used.",

--- a/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
@@ -11,7 +11,7 @@ spec:
   brokerK8sRemoteNamespace: {{ .BrokerNamespace }}
   brokerK8sInsecure: {{ .InsecureBrokerConnection }}
   cableDriver: {{ .CableDriver }}
-  ceIPSecDebug: false
+  ceIPSecDebug: {{ .IPSecDebug }}
   ceIPSecNATTPort: {{ .IPSecNATTPort }}
   ceIPSecPSK: {{ .IPSecPSK }}
   clusterCIDR: ""
@@ -20,7 +20,7 @@ spec:
   loadBalancerEnabled: {{ .LoadBalancerEnabled }}
   clusterID: {{ .ClusterName }}
   colorCodes: blue
-  debug: false
+  debug: {{ .Debug }}
   namespace: {{ .InstallationNamespace }}
   natEnabled: {{ .NATEnabled }}
   serviceCIDR: ""

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo.go
@@ -64,6 +64,8 @@ type SubmarinerBrokerInfo struct {
 	NATEnabled                         bool
 	LoadBalancerEnabled                bool
 	InsecureBrokerConnection           bool
+	IPSecDebug                         bool
+	Debug                              bool
 	IPSecNATTPort                      int
 	InstallationNamespace              string
 	InstallPlanApproval                string
@@ -202,6 +204,8 @@ func applySubmarinerConfig(brokerInfo *SubmarinerBrokerInfo, submarinerConfig *c
 	brokerInfo.NATEnabled = submarinerConfig.Spec.NATTEnable
 	brokerInfo.LoadBalancerEnabled = submarinerConfig.Spec.LoadBalancerEnable
 	brokerInfo.InsecureBrokerConnection = submarinerConfig.Spec.InsecureBrokerConnection
+	brokerInfo.Debug = submarinerConfig.Spec.Debug
+	brokerInfo.IPSecDebug = submarinerConfig.Spec.IPSecDebug
 
 	if submarinerConfig.Spec.CableDriver != "" {
 		brokerInfo.CableDriver = submarinerConfig.Spec.CableDriver


### PR DESCRIPTION
The addon currently forcibly disables debugging in Submariner. This changes that; debugging Submariner and IPSec can be enabled in SubmarinerConfig.