### PR TITLE
Preserve Gateway labels added by the user

### DIFF
--- a/pkg/spoke/submarineragent/gateways_controller.go
+++ b/pkg/spoke/submarineragent/gateways_controller.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	submarinerGatewayLabel        = "submariner.io/gateway"
+	gatewayLabeledBySubmariner    = "submariner.io/random-gateway-node"
 	submarinerGatewayNodesLabeled = "SubmarinerGatewayNodesLabeled"
 )
 


### PR DESCRIPTION
For certain platforms like VmWare, Submariner addon labels one (or more) of the existing worker nodes as Gateway nodes when its installed on the ManagedCluster. However, if the clusterAdmin/user explicitly requires certain nodes to be used as Gateway nodes, we recommend that `submariner.io/gateway=true` label has to be added to the desired nodes. Currently, the addon code looks for the presence of `submariner.io/gateway=true` label and uses those nodes accordingly, but when its later uninstalled, it removes the label from the node which was originally added by the user.

This PR ensures that the label is preserved if its not added by the submariner-addon.