### PR TITLE
Actually run CRD/CSV verifications in verify CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ vendor: go.mod
 	$(GO) mod tidy
 	$(GO) mod vendor
 
-verify: vendor verify-gofmt verify-govet verify-scripts
+verify: vendor verify-gofmt verify-govet verify-scripts verify-csv verify-crds
 
 verify-gofmt:
 	$(info Running gofmt -s -l on $(go_files_count) file(s).)


### PR DESCRIPTION
The Prow CI has a verify job that runs `make verify`, but we don't include the CRD and CSV verification targets in the overall target.

This is needed to avoid missing updates (see #291/#292).

Fixes: https://issues.redhat.com/browse/ACM-2847