### PR TITLE
Ensure ManagedCluster finalizer removed if add-on does not exist

### DIFF
--- a/pkg/hub/submarineragent/controller_test.go
+++ b/pkg/hub/submarineragent/controller_test.go
@@ -251,6 +251,17 @@ var _ = Describe("Controller", func() {
 		t.testAgentCleanup()
 	})
 
+	When("the ManagedCluster is being deleted and the ManagedClusterAddon doesn't exist", func() {
+		JustBeforeEach(func() {
+			t.initManifestWorks()
+			test.SetDeleting(resource.ForManagedCluster(t.clusterClient.ClusterV1().ManagedClusters()), t.managedCluster.Name)
+			Expect(t.addOnClient.AddonV1alpha1().ManagedClusterAddOns(clusterName).Delete(
+				context.Background(), t.addOn.Name, metav1.DeleteOptions{})).To(Succeed())
+		})
+
+		t.testAgentCleanup()
+	})
+
 	When("the ManagedCluster is removed from the ManagedClusterSet", func() {
 		JustBeforeEach(func() {
 			t.initManifestWorks()
@@ -410,8 +421,12 @@ func (t *testDriver) testAgentCleanup() {
 	})
 
 	It("should delete the finalizers", func() {
-		test.AwaitNoFinalizer(resource.ForAddon(t.addOnClient.AddonV1alpha1().ManagedClusterAddOns(clusterName)),
-			t.addOn.Name, submarineragent.AddOnFinalizer)
+		_, err := t.addOnClient.AddonV1alpha1().ManagedClusterAddOns(clusterName).Get(context.Background(), t.addOn.Name, metav1.GetOptions{})
+		if !apierrors.IsNotFound(err) {
+			test.AwaitNoFinalizer(resource.ForAddon(t.addOnClient.AddonV1alpha1().ManagedClusterAddOns(clusterName)),
+				t.addOn.Name, submarineragent.AddOnFinalizer)
+		}
+
 		test.AwaitNoFinalizer(resource.ForManagedCluster(t.clusterClient.ClusterV1().ManagedClusters()), clusterName,
 			submarineragent.AgentFinalizer)
 	})


### PR DESCRIPTION
The submarinerAgentController assumes the submariner ManagedClusterAddOn exists when cleaning up on ManagedCluster deletion. However, if it doesn't, cleanup never completes and the finalizer is not removed from the ManagedCluster. This shouldn't normally happen since the controller aso adds a finalizer to the ManagedClusterAddOn but this scenario was observed in a real installation
(see https://issues.redhat.com/browse/ACM-5381).

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>
(cherry picked from commit 4685987c45ba1364a9687d57bb0740274314c6cc)