### PR TITLE
Ensure ManagedCluster finalizer removed if add-on does not exist

### DIFF
--- a/pkg/hub/submarineragent/controller.go
+++ b/pkg/hub/submarineragent/controller.go
@@ -277,6 +277,29 @@ func (c *submarinerAgentController) syncManagedCluster(
 	managedCluster *clusterv1.ManagedCluster,
 	config *configv1alpha1.SubmarinerConfig,
 ) error {
+	// managed cluster is deleting, we remove its related resources
+	if !managedCluster.DeletionTimestamp.IsZero() {
+		return c.cleanUpSubmarinerAgent(ctx, managedCluster)
+	}
+
+	clusterSetName, existed := managedCluster.Labels[clusterv1beta1.ClusterSetLabel]
+	if !existed {
+		// the cluster does not have the clusterset label, try to clean up the submariner agent
+		return c.cleanUpSubmarinerAgent(ctx, managedCluster)
+	}
+
+	// find the clustersets that contains this managed cluster
+	_, err := c.clusterSetLister.Get(clusterSetName)
+
+	switch {
+	case apierrors.IsNotFound(err):
+		// if one cluster has clusterset label, but the clusterset is not found, it could have been deleted
+		// try to clean up the submariner agent
+		return c.cleanUpSubmarinerAgent(ctx, managedCluster)
+	case err != nil:
+		return err
+	}
+
 	// find the submariner-addon on the managed cluster namespace
 	addOn, err := c.addOnLister.ManagedClusterAddOns(managedCluster.Name).Get(constants.SubmarinerAddOnName)
 
@@ -288,32 +311,9 @@ func (c *submarinerAgentController) syncManagedCluster(
 		return err
 	}
 
-	// managed cluster is deleting, we remove its related resources
-	if !managedCluster.DeletionTimestamp.IsZero() {
-		return c.cleanUpSubmarinerAgent(ctx, managedCluster, addOn)
-	}
-
-	clusterSetName, existed := managedCluster.Labels[clusterv1beta1.ClusterSetLabel]
-	if !existed {
-		// the cluster does not have the clusterset label, try to clean up the submariner agent
-		return c.cleanUpSubmarinerAgent(ctx, managedCluster, addOn)
-	}
-
-	// find the clustersets that contains this managed cluster
-	_, err = c.clusterSetLister.Get(clusterSetName)
-
-	switch {
-	case apierrors.IsNotFound(err):
-		// if one cluster has clusterset label, but the clusterset is not found, it could have been deleted
-		// try to clean up the submariner agent
-		return c.cleanUpSubmarinerAgent(ctx, managedCluster, addOn)
-	case err != nil:
-		return err
-	}
-
 	// submariner-addon is deleting, we remove its related resources
 	if !addOn.DeletionTimestamp.IsZero() {
-		return c.cleanUpSubmarinerAgent(ctx, managedCluster, addOn)
+		return c.cleanUpSubmarinerAgent(ctx, managedCluster)
 	}
 
 	// add a submariner agent finalizer to a managed cluster
@@ -423,9 +423,7 @@ func (c *submarinerAgentController) skipSyncingUnchangedConfig(config *configv1a
 }
 
 // clean up the submariner agent from this managedCluster.
-func (c *submarinerAgentController) cleanUpSubmarinerAgent(ctx context.Context, managedCluster *clusterv1.ManagedCluster,
-	addOn *addonv1alpha1.ManagedClusterAddOn,
-) error {
+func (c *submarinerAgentController) cleanUpSubmarinerAgent(ctx context.Context, managedCluster *clusterv1.ManagedCluster) error {
 	submarinerManifestWork, err := c.manifestWorkLister.ManifestWorks(managedCluster.Name).Get(SubmarinerCRManifestWorkName)
 
 	switch {
@@ -451,8 +449,13 @@ func (c *submarinerAgentController) cleanUpSubmarinerAgent(ctx context.Context, 
 		return err
 	}
 
-	return finalizer.Remove(ctx, resource.ForAddon(c.addOnClient.AddonV1alpha1().ManagedClusterAddOns(managedCluster.Name)),
-		addOn, AddOnFinalizer)
+	addOn, err := c.addOnLister.ManagedClusterAddOns(managedCluster.Name).Get(constants.SubmarinerAddOnName)
+	if err == nil {
+		return finalizer.Remove(ctx, resource.ForAddon(c.addOnClient.AddonV1alpha1().ManagedClusterAddOns(managedCluster.Name)),
+			addOn, AddOnFinalizer)
+	}
+
+	return nil
 }
 
 func (c *submarinerAgentController) deploySubmarinerAgent(

--- a/pkg/hub/submarineragent/controller_test.go
+++ b/pkg/hub/submarineragent/controller_test.go
@@ -237,6 +237,17 @@ var _ = Describe("Controller", func() {
 		t.testAgentCleanup()
 	})
 
+	When("the ManagedCluster is being deleted and the ManagedClusterAddon doesn't exist", func() {
+		JustBeforeEach(func() {
+			t.initManifestWorks()
+			test.SetDeleting(resource.ForManagedCluster(t.clusterClient.ClusterV1().ManagedClusters()), t.managedCluster.Name)
+			Expect(t.addOnClient.AddonV1alpha1().ManagedClusterAddOns(clusterName).Delete(
+				context.Background(), t.addOn.Name, metav1.DeleteOptions{})).To(Succeed())
+		})
+
+		t.testAgentCleanup()
+	})
+
 	When("the ManagedCluster is removed from the ManagedClusterSet", func() {
 		JustBeforeEach(func() {
 			t.initManifestWorks()
@@ -392,8 +403,12 @@ func (t *testDriver) testAgentCleanup() {
 	})
 
 	It("should delete the finalizers", func() {
-		test.AwaitNoFinalizer(resource.ForAddon(t.addOnClient.AddonV1alpha1().ManagedClusterAddOns(clusterName)),
-			t.addOn.Name, submarineragent.AddOnFinalizer)
+		_, err := t.addOnClient.AddonV1alpha1().ManagedClusterAddOns(clusterName).Get(context.Background(), t.addOn.Name, metav1.GetOptions{})
+		if !apierrors.IsNotFound(err) {
+			test.AwaitNoFinalizer(resource.ForAddon(t.addOnClient.AddonV1alpha1().ManagedClusterAddOns(clusterName)),
+				t.addOn.Name, submarineragent.AddOnFinalizer)
+		}
+
 		test.AwaitNoFinalizer(resource.ForManagedCluster(t.clusterClient.ClusterV1().ManagedClusters()), clusterName,
 			submarineragent.AgentFinalizer)
 	})


### PR DESCRIPTION
The submarinerAgentController assumes the submariner ManagedClusterAddOn exists when cleaning up on ManagedCluster deletion. However, if it doesn't, cleanup never completes and the finalizer is not removed from the ManagedCluster. This shouldn't normally happen since the controller aso adds a finalizer to the ManagedClusterAddOn but this scenario was observed in a real installation
(see https://issues.redhat.com/browse/ACM-5381).

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>
(cherry picked from commit 4685987c45ba1364a9687d57bb0740274314c6cc)