### PR TITLE
Set default gateways count to one in submarinerConfig

### DIFF
--- a/pkg/apis/submarinerconfig/v1alpha1/types.go
+++ b/pkg/apis/submarinerconfig/v1alpha1/types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"encoding/json"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -194,7 +196,7 @@ type GatewayConfig struct {
 	// Submariner gateway HA will be enabled automatically.
 	// +optional
 	// +kubebuilder:default=1
-	Gateways int `json:"gateways,omitempty"`
+	Gateways int `json:"gateways"`
 }
 
 type AWS struct {
@@ -288,4 +290,22 @@ type SubmarinerConfigList struct {
 
 	// Items is a list of SubmarinerConfig.
 	Items []SubmarinerConfig `json:"items"`
+}
+
+func (s *SubmarinerConfig) UnmarshalJSON(data []byte) error {
+	type SubmarinerConfigAlias SubmarinerConfig
+
+	subm := &SubmarinerConfigAlias{
+		Spec: SubmarinerConfigSpec{
+			GatewayConfig: GatewayConfig{
+				Gateways: 1,
+			},
+		},
+	}
+
+	_ = json.Unmarshal(data, subm)
+
+	*s = SubmarinerConfig(*subm)
+
+	return nil
 }


### PR DESCRIPTION
Currently, the SubmarinerConfigSpec specifies gatewayConfig as an Optional field and because of this, when users create a near empty SubmarinerConfig, the deployment does not create any gateways. This PR removes the Optional field from gateways, so that a default gateway of one is used in such deployments.