### PR TITLE
Disable depguard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,7 @@ linters:
     - contextcheck
     # - cyclop # This is equivalent to gocyclo
     - decorder
-    - depguard
+    # - depguard # depguard now denies by default, it should only be enabled if we actually use it
     - dogsled
     - dupl
     - dupword


### PR DESCRIPTION
Newer versions of depguard, as used in golangci-lint 1.53.0 and later, deny imports by default. As a result, depguard should only be enabled if it's going to be used, which isn't the case currently in Submariner projects.