### PR TITLE
Bump to golangci-lint 1.54.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
-GOLANGCI_LINT_VERSION=v1.52.2
+GOLANGCI_LINT_VERSION=v1.54.2
 GOLANGCI_LINT?=$(PERMANENT_TMP_GOPATH)/bin/golangci-lint
 
 $(GOLANGCI_LINT):


### PR DESCRIPTION
This adds support for Go 1.21.

Changes:
* https://github.com/golangci/golangci-lint/releases/tag/v1.53.0
* https://github.com/golangci/golangci-lint/releases/tag/v1.53.1
* https://github.com/golangci/golangci-lint/releases/tag/v1.53.2
* https://github.com/golangci/golangci-lint/releases/tag/v1.53.3
* https://github.com/golangci/golangci-lint/releases/tag/v1.54.0
* https://github.com/golangci/golangci-lint/releases/tag/v1.54.1
* https://github.com/golangci/golangci-lint/releases/tag/v1.54.2