### PR TITLE
Remove code accessing the ServiceAccount Secret field

### DIFF
--- a/pkg/hub/submarineragent/controller_test.go
+++ b/pkg/hub/submarineragent/controller_test.go
@@ -450,12 +450,12 @@ func newTestDriver() *testDriver {
 					Name:      clusterName,
 					Namespace: brokerNamespace,
 				},
-				Secrets: []corev1.ObjectReference{{Name: clusterName + "-token-5pw5c"}},
 			},
 			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName + "-token-5pw5c",
-					Namespace: brokerNamespace,
+					Name:        clusterName + "-token-5pw5c",
+					Namespace:   brokerNamespace,
+					Annotations: map[string]string{corev1.ServiceAccountNameKey: clusterName},
 				},
 				Data: map[string][]byte{
 					"ca.crt": []byte(brokerCA),

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
@@ -83,13 +83,13 @@ var _ = Describe("Function Get", func() {
 				Name:      clusterName,
 				Namespace: brokerNamespace,
 			},
-			Secrets: []corev1.ObjectReference{{Name: "other"}, {Name: clusterName + "-token-5pw5c"}},
 		}
 
 		serviceAccountSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      clusterName + "-token-5pw5c",
-				Namespace: brokerNamespace,
+				Name:        clusterName + "-token-5pw5c",
+				Namespace:   brokerNamespace,
+				Annotations: map[string]string{corev1.ServiceAccountNameKey: serviceAccount.Name},
 			},
 			Data: map[string][]byte{
 				"ca.crt": []byte(brokerCA),
@@ -348,16 +348,6 @@ var _ = Describe("Function Get", func() {
 	When("the cluster ServiceAccount resource is missing", func() {
 		BeforeEach(func() {
 			kubeObjs = []runtime.Object{ipsecSecret, serviceAccountSecret}
-		})
-
-		It("should return an error", func() {
-			Expect(err).ToNot(Succeed())
-		})
-	})
-
-	When("the cluster ServiceAccount resource has no Secrets", func() {
-		BeforeEach(func() {
-			serviceAccount.Secrets = []corev1.ObjectReference{}
 		})
 
 		It("should return an error", func() {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -141,10 +141,6 @@ func SetupServiceAccount(kubeClient kubernetes.Interface, namespace, name string
 			}
 
 			secretName := fmt.Sprintf("%s-token-%s", name, rand.String(5))
-			sa.Secrets = []corev1.ObjectReference{{Name: secretName}}
-			if _, err := kubeClient.CoreV1().ServiceAccounts(namespace).Update(ctx, sa, metav1.UpdateOptions{}); err != nil {
-				return false, err
-			}
 
 			// create a serviceaccount token secret
 			secret := &corev1.Secret{
@@ -152,7 +148,7 @@ func SetupServiceAccount(kubeClient kubernetes.Interface, namespace, name string
 					Namespace: namespace,
 					Name:      secretName,
 					Annotations: map[string]string{
-						"kubernetes.io/service-account.name": sa.Name,
+						corev1.ServiceAccountNameKey: sa.Name,
 					},
 				},
 				Data: map[string][]byte{


### PR DESCRIPTION
As of K8s 1.24, token `Secrets` are no longer auto-generated and this field no longer populated.