### PR TITLE
Ensure the agent has a writable /tmp

### DIFF
--- a/deploy/config/operator/operator.yaml
+++ b/deploy/config/operator/operator.yaml
@@ -1,3 +1,4 @@
+---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -17,32 +18,38 @@ spec:
     spec:
       serviceAccountName: submariner-addon
       containers:
-      - name: submariner-addon
-        image: quay.io/stolostron/submariner-addon:latest
-        args:
-          - "/submariner"
-          - "controller"
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            scheme: HTTPS
-            port: 8443
-          initialDelaySeconds: 2
-          periodSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            scheme: HTTPS
-            port: 8443
-          initialDelaySeconds: 2
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-          limits:
-            memory: 270Mi
-        env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
+        - name: submariner-addon
+          image: quay.io/stolostron/submariner-addon:latest
+          args:
+            - "/submariner"
+            - "controller"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              scheme: HTTPS
+              port: 8443
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              scheme: HTTPS
+              port: 8443
+            initialDelaySeconds: 2
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 270Mi
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
@@ -317,7 +317,13 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 128Mi
+                volumeMounts:
+                - mountPath: /tmp
+                  name: tmp
               serviceAccountName: submariner-addon
+              volumes:
+              - emptyDir: {}
+                name: tmp
     strategy: deployment
   installModes:
   - supported: true

--- a/pkg/hub/submarineraddonagent/manifests/deployment.yaml
+++ b/pkg/hub/submarineraddonagent/manifests/deployment.yaml
@@ -30,10 +30,14 @@ spec:
         volumeMounts:
           - name: hub-config
             mountPath: /var/run/hub
+          - name: tmp
+            mountPath: /tmp
       volumes:
       - name: hub-config
         secret:
           secretName: {{ .KubeConfigSecret }}
+      - name: tmp
+        emptyDir: {}
       {{- if .NodeSelector }}
       nodeSelector:
       {{- range $key, $value := .NodeSelector }}


### PR DESCRIPTION
When run with read-only root, the agent fails because it expects to be able to write to /tmp. This adds a writable /tmp.

The addon's specific use of a writable /tmp is tied to certificate provisioning, and the correct long-term fix is to manage its certificates externally; but until that's done, providing a writable /tmp has no adverse effects and allows read-only root deployments.