### PR TITLE
Refactor/cleanup integration tests

### DIFF
--- a/pkg/hub/manager.go
+++ b/pkg/hub/manager.go
@@ -185,12 +185,13 @@ func (o *AddOnOptions) RunControllerManager(ctx context.Context, controllerConte
 		controllerContext.EventRecorder,
 	)
 
-	go clusterInformers.Start(ctx.Done())
-	go workInformers.Start(ctx.Done())
-	go kubeInformers.Start(ctx.Done())
-	go configInformers.Start(ctx.Done())
-	go apiExtensionsInformers.Start(ctx.Done())
-	go addOnInformers.Start(ctx.Done())
+	clusterInformers.Start(ctx.Done())
+	workInformers.Start(ctx.Done())
+	kubeInformers.Start(ctx.Done())
+	configInformers.Start(ctx.Done())
+	apiExtensionsInformers.Start(ctx.Done())
+	addOnInformers.Start(ctx.Done())
+
 	go submarinerBrokerCRDsController.Run(ctx, 1)
 	go submarinerBrokerController.Run(ctx, 1)
 	go submarinerAgentController.Run(ctx, 1)
@@ -206,12 +207,10 @@ func (o *AddOnOptions) RunControllerManager(ctx context.Context, controllerConte
 		return err
 	}
 
-	go func() {
-		err := mgr.Start(ctx)
-		if err != nil {
-			klog.Fatalf("Error starting the manager: %v", err)
-		}
-	}()
+	err = mgr.Start(ctx)
+	if err != nil {
+		return err
+	}
 
 	<-ctx.Done()
 

--- a/test/integration-test.mk
+++ b/test/integration-test.mk
@@ -28,5 +28,5 @@ clean: clean-integration-test
 
 test-integration: ensure-kubebuilder-tools
 	go test -c ./test/integration
-	./integration.test -ginkgo.slowSpecThreshold=15 -ginkgo.v -ginkgo.failFast
+	./integration.test -ginkgo.v -ginkgo.fail-fast
 .PHONY: test-integration

--- a/test/integration/deploying_addonagent_test.go
+++ b/test/integration/deploying_addonagent_test.go
@@ -62,9 +62,6 @@ var _ = Describe("Submariner addon agent", func() {
 			installationNamespace, err = util.GetCurrentNamespace(kubeClient, "submariner-operator")
 			Expect(err).ToNot(HaveOccurred())
 
-			// save the kubeconfig to a file, simulate agent mount hub kubeconfig secret that was created by addon framework
-			Expect(util.CreateHubKubeConfig(cfg)).ToNot(HaveOccurred())
-
 			By(fmt.Sprintf("Start submariner spoke agent on managed cluster namespace %q", installationNamespace))
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -74,7 +71,7 @@ var _ = Describe("Submariner addon agent", func() {
 
 				agentOptions := spoke.AgentOptions{
 					InstallationNamespace: installationNamespace,
-					HubKubeconfigFile:     util.HubKubeConfigPath,
+					HubRestConfig:         cfg,
 					ClusterName:           managedClusterName,
 				}
 
@@ -107,7 +104,7 @@ var _ = Describe("Submariner addon agent", func() {
 					constants.SubmarinerAddOnName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				return !meta.IsStatusConditionTrue(addOn.Status.Conditions, "SubmarinerConnectionDegraded")
+				return meta.IsStatusConditionTrue(addOn.Status.Conditions, "SubmarinerConnectionDegraded")
 			}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
 		})
 	})

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -19,9 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/retry"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
@@ -34,8 +30,6 @@ const (
 	expectedBrokerRole  = "submariner-k8s-broker-cluster"
 	expectedIPSECSecret = "submariner-ipsec-psk"
 )
-
-var HubKubeConfigPath = path.Join("/tmp", "submaddon-integration-test", "kubeconfig")
 
 // on prow env, the /var/run/secrets/kubernetes.io/serviceaccount/namespace can be found.
 func GetCurrentNamespace(kubeClient kubernetes.Interface, defaultNamespace string) (string, error) {
@@ -52,19 +46,6 @@ func GetCurrentNamespace(kubeClient kubernetes.Interface, defaultNamespace strin
 	}
 
 	return namespace, nil
-}
-
-func CreateHubKubeConfig(cfg *rest.Config) error {
-	config := clientcmdapi.NewConfig()
-	config.Clusters["hub"] = &clientcmdapi.Cluster{
-		Server: cfg.Host,
-	}
-	config.Contexts["hub"] = &clientcmdapi.Context{
-		Cluster: "hub",
-	}
-	config.CurrentContext = "hub"
-
-	return clientcmd.WriteToFile(*config, HubKubeConfigPath)
 }
 
 func UpdateManagedClusterLabels(clusterClient clusterclientset.Interface, managedClusterName string, labels map[string]string) error {


### PR DESCRIPTION
General outline below but see individual commits for details.
 
- Refactor common/duplicate code to reusable functions
 - Improve test description and trace text
 - Remove unnecessary code
 - Fix the spoke agent test case
 - Gracefully stop controller manager in `AfterSuite`
