### PR TITLE
Use CreateOrUpdate for the ClusterManagementAddOn 

### DIFF
--- a/test/integration/deploying_addonagent_test.go
+++ b/test/integration/deploying_addonagent_test.go
@@ -30,6 +30,8 @@ var _ = Describe("Submariner addon agent", func() {
 
 	When("the submariner addon agent is deployed", func() {
 		BeforeEach(func() {
+			DeferCleanup(startControllerManager())
+
 			managedClusterSetName, brokerNamespace := deployManagedClusterSet()
 			deployManagedClusterWithAddOn(managedClusterSetName, managedClusterName, brokerNamespace)
 		})

--- a/test/integration/deploying_submariner_test.go
+++ b/test/integration/deploying_submariner_test.go
@@ -32,6 +32,8 @@ var _ = Describe("Submariner Deployment", func() {
 	BeforeEach(func() {
 		managedClusterName = fmt.Sprintf("cluster-%s", rand.String(6))
 
+		DeferCleanup(startControllerManager())
+
 		managedClusterSetName, brokerNamespace = deployManagedClusterSet()
 	})
 
@@ -165,20 +167,6 @@ var _ = Describe("Submariner Deployment", func() {
 			_, err = addOnClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addOn,
 				metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			if clusterAddOn != nil {
-				By("Re-create the ClusterManagementAddOn")
-
-				clusterAddOn.ResourceVersion = ""
-
-				_, err := addOnClient.AddonV1alpha1().ClusterManagementAddOns().Create(context.Background(), clusterAddOn,
-					metav1.CreateOptions{})
-				if !apierrors.IsAlreadyExists(err) {
-					Expect(err).NotTo(HaveOccurred())
-				}
-			}
 		})
 
 		It("should remove the broker resources for the associated ManagedClusterSets", func() {


### PR DESCRIPTION
...to handle upgrades. This is initially to ensure the finalizer is added but will be useful in the future if the spec is ever changed.

Also added integration test case. See individual commits for details.