### PR TITLE
Reduce ProviderFactory.Get method signature

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -29,8 +29,7 @@ type Provider interface {
 }
 
 type ProviderFactory interface {
-	Get(managedClusterInfo *configv1alpha1.ManagedClusterInfo, config *configv1alpha1.SubmarinerConfig,
-		eventsRecorder events.Recorder) (Provider, bool, error)
+	Get(config *configv1alpha1.SubmarinerConfig, eventsRecorder events.Recorder) (Provider, bool, error)
 }
 
 type providerFactory struct {
@@ -77,9 +76,9 @@ func NewProviderFactory(restMapper meta.RESTMapper, kubeClient kubernetes.Interf
 	}
 }
 
-func (f *providerFactory) Get(managedClusterInfo *configv1alpha1.ManagedClusterInfo, config *configv1alpha1.SubmarinerConfig,
-	eventsRecorder events.Recorder,
-) (Provider, bool, error) {
+func (f *providerFactory) Get(config *configv1alpha1.SubmarinerConfig, eventsRecorder events.Recorder) (Provider, bool, error) {
+	managedClusterInfo := &config.Status.ManagedClusterInfo
+
 	klog.V(4).Infof("Get cloud provider: ManagedClusterInfo: %#v", managedClusterInfo)
 
 	info := &provider.Info{

--- a/pkg/cloud/fake/cloud.go
+++ b/pkg/cloud/fake/cloud.go
@@ -88,9 +88,9 @@ func (m *MockProviderFactory) EXPECT() *MockProviderFactoryMockRecorder {
 }
 
 // Get mocks base method.
-func (m *MockProviderFactory) Get(managedClusterInfo *v1alpha1.ManagedClusterInfo, config *v1alpha1.SubmarinerConfig, eventsRecorder events.Recorder) (cloud.Provider, bool, error) {
+func (m *MockProviderFactory) Get(config *v1alpha1.SubmarinerConfig, eventsRecorder events.Recorder) (cloud.Provider, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", managedClusterInfo, config, eventsRecorder)
+	ret := m.ctrl.Call(m, "Get", config, eventsRecorder)
 	ret0, _ := ret[0].(cloud.Provider)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -98,7 +98,7 @@ func (m *MockProviderFactory) Get(managedClusterInfo *v1alpha1.ManagedClusterInf
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockProviderFactoryMockRecorder) Get(managedClusterInfo, config, eventsRecorder interface{}) *gomock.Call {
+func (mr *MockProviderFactoryMockRecorder) Get(config, eventsRecorder interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockProviderFactory)(nil).Get), managedClusterInfo, config, eventsRecorder)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockProviderFactory)(nil).Get), config, eventsRecorder)
 }

--- a/pkg/spoke/submarineragent/config_controller.go
+++ b/pkg/spoke/submarineragent/config_controller.go
@@ -240,7 +240,7 @@ func (c *submarinerConfigController) skipSyncingUnchangedConfig(config *configv1
 func (c *submarinerConfigController) prepareForSubmariner(ctx context.Context, config *configv1alpha1.SubmarinerConfig,
 	recorder events.Recorder,
 ) error {
-	cloudProvider, providerFound, preparedErr := c.cloudProviderFactory.Get(&config.Status.ManagedClusterInfo, config, recorder)
+	cloudProvider, providerFound, preparedErr := c.cloudProviderFactory.Get(config, recorder)
 	errs := []error{}
 
 	if providerFound && preparedErr == nil {
@@ -301,7 +301,7 @@ func (c *submarinerConfigController) prepareForSubmariner(ctx context.Context, c
 func (c *submarinerConfigController) cleanupClusterEnvironment(ctx context.Context, config *configv1alpha1.SubmarinerConfig,
 	recorder events.Recorder,
 ) error {
-	cloudProvider, found, err := c.cloudProviderFactory.Get(&config.Status.ManagedClusterInfo, config, recorder)
+	cloudProvider, found, err := c.cloudProviderFactory.Get(config, recorder)
 	if !found {
 		return errors.WithMessagef(c.removeAllGateways(ctx), "failed to unlabel the gateway nodes")
 	}

--- a/pkg/spoke/submarineragent/config_controller_test.go
+++ b/pkg/spoke/submarineragent/config_controller_test.go
@@ -3,6 +3,8 @@ package submarineragent_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"reflect"
 	"strconv"
 	"time"
 
@@ -692,8 +694,7 @@ func (t *configControllerTestDriver) expectProviderFactoryGet() {
 			provider = nil
 		}
 
-		t.providerFactory.EXPECT().Get(&t.config.Status.ManagedClusterInfo, gomock.Not(gomock.Nil()), gomock.Any()).
-			Return(provider, provider != nil, nil).AnyTimes()
+		t.providerFactory.EXPECT().Get(eqSubmarinerConfig(t.config), gomock.Any()).Return(provider, provider != nil, nil).AnyTimes()
 	}
 }
 
@@ -832,4 +833,24 @@ func newSubmarinerConfig() *configv1alpha1.SubmarinerConfig {
 			},
 		},
 	}
+}
+
+func eqSubmarinerConfig(expected *configv1alpha1.SubmarinerConfig) gomock.Matcher {
+	return submarinerConfigMatcher{expected: expected}
+}
+
+type submarinerConfigMatcher struct {
+	expected *configv1alpha1.SubmarinerConfig
+}
+
+func (m submarinerConfigMatcher) Matches(x interface{}) bool {
+	if x == nil {
+		return false
+	}
+
+	return reflect.DeepEqual(m.expected.Status.ManagedClusterInfo, x.(*configv1alpha1.SubmarinerConfig).Status.ManagedClusterInfo)
+}
+
+func (m submarinerConfigMatcher) String() string {
+	return fmt.Sprintf("is equal to %v", m.expected)
 }


### PR DESCRIPTION
The `ManagedClusterInfo` is part of `SubmarinerConfig.Status` so no need to pass it in separately.