### PR TITLE
Fix concurrent map read/write panic in resourceapply module

### DIFF
--- a/pkg/hub/submarinerbroker/controller.go
+++ b/pkg/hub/submarinerbroker/controller.go
@@ -58,6 +58,7 @@ type submarinerBrokerController struct {
 	clusterAddOnLister addonlisterv1alpha1.ClusterManagementAddOnLister
 	addOnLister        addonlisterv1alpha1.ManagedClusterAddOnLister
 	eventRecorder      events.Recorder
+	resourceCache      resourceapply.ResourceCache
 }
 
 type brokerConfig struct {
@@ -79,6 +80,7 @@ func NewController(kubeClient kubernetes.Interface,
 		clusterAddOnLister: addOnInformer.ClusterManagementAddOns().Lister(),
 		addOnLister:        addOnInformer.ManagedClusterAddOns().Lister(),
 		eventRecorder:      recorder.WithComponentSuffix("submariner-broker-controller"),
+		resourceCache:      resourceapply.NewResourceCache(),
 	}
 
 	return factory.New().
@@ -203,7 +205,7 @@ func (c *submarinerBrokerController) reconcileManagedClusterSet(ctx context.Cont
 	}
 
 	// Apply static files
-	err := resource.ApplyManifests(ctx, c.kubeClient, recorder, assetFunc(brokerNS), staticResourceFiles...)
+	err := resource.ApplyManifests(ctx, c.kubeClient, recorder, c.resourceCache, assetFunc(brokerNS), staticResourceFiles...)
 	if err != nil {
 		return err
 	}

--- a/pkg/resource/manifest.go
+++ b/pkg/resource/manifest.go
@@ -31,7 +31,6 @@ var logger = log.Logger{Logger: logf.Log.WithName("Resource")}
 var (
 	genericScheme = runtime.NewScheme()
 	genericCodec  = serializer.NewCodecFactory(genericScheme).UniversalDeserializer()
-	resourceCache = resourceapply.NewResourceCache()
 )
 
 func init() {
@@ -42,9 +41,9 @@ func init() {
 }
 
 func ApplyManifests(ctx context.Context, kubeClient kubernetes.Interface, recorder events.Recorder,
-	assetFunc resourceapply.AssetFunc, files ...string,
+	cache resourceapply.ResourceCache, assetFunc resourceapply.AssetFunc, files ...string,
 ) error {
-	applyResults := resourceapply.ApplyDirectly(ctx, resourceapply.NewKubeClientHolder(kubeClient), recorder, resourceCache,
+	applyResults := resourceapply.ApplyDirectly(ctx, resourceapply.NewKubeClientHolder(kubeClient), recorder, cache,
 		assetFunc, files...)
 
 	errs := []error{}


### PR DESCRIPTION
In `resource.ApplyManifests`, we call `resourceapply.ApplyDirectly` and pass in a global `ResourceCache`. However we have 2 controllers that use this function which can result in concurrent access to the `ResourceCache` as the controllers run on different threads. This was observed in a recent integration test run. To alleviate this, modify each controller to have its own `ResourceCache` instance and pass to resource.ApplyManifests.