### PR TITLE
Use k8s.io/utils/ptr instead of smithy-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.20
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.4.0
-	github.com/aws/smithy-go v1.15.0
 	github.com/coreos/go-semver v0.3.1
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/gophercloud/gophercloud v1.7.0
@@ -61,6 +60,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.13.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.15.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.21.5 // indirect
+	github.com/aws/smithy-go v1.15.0 // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/pkg/hub/submarinerbroker/brokerCRDsController.go
+++ b/pkg/hub/submarinerbroker/brokerCRDsController.go
@@ -3,7 +3,6 @@ package submarinerbroker
 import (
 	"context"
 
-	"github.com/aws/smithy-go/ptr"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/stolostron/submariner-addon/pkg/resource"
@@ -16,6 +15,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -77,8 +77,8 @@ func (c *submarinerBrokerCRDsController) sync(ctx context.Context, syncCtx facto
 		Kind:               "CustomResourceDefinition",
 		Name:               configCRD.GetName(),
 		UID:                configCRD.GetUID(),
-		Controller:         ptr.Bool(true),
-		BlockOwnerDeletion: ptr.Bool(true),
+		Controller:         ptr.To(true),
+		BlockOwnerDeletion: ptr.To(true),
 	}
 
 	return resource.ApplyCRDs(ctx, c.crdClient, syncCtx.Recorder(), ownerRef, func(yaml string) ([]byte, error) {


### PR DESCRIPTION
There's no need to have a direct dependency on the latter.