### PR TITLE
Add Grype vuln scanning/reporting

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,0 +1,33 @@
+---
+name: Reporting
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+
+permissions: {}
+
+jobs:
+  vulnerability-scan:
+    name: Vulnerability Scanning
+    if: github.repository_owner == 'stolostron'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Run Anchore vulnerability scanner
+        uses: anchore/scan-action@24fd7c9060f3c96848dd1929fac8d796fb5ae4b4
+        id: scan
+        with:
+          path: "."
+          fail-build: false
+      - name: Show Anchore scan SARIF report
+        run: cat ${{ steps.scan.outputs.sarif }}
+      - name: Upload Anchore scan SARIF report
+        uses: github/codeql-action/upload-sarif@74483a38d39275f33fcff5f35b679b5ca4a26a99
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}


### PR DESCRIPTION
This will report to GitHub's Code Scanning reports, showing known CVEs in our go dependencies.