### PR TITLE
Configure OpenShift profiler settings on the spoke

### DIFF
--- a/pkg/hub/submarineraddonagent/agent.go
+++ b/pkg/hub/submarineraddonagent/agent.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"encoding/pem"
 	"fmt"
+	"os"
 
 	"github.com/openshift/library-go/pkg/assets"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -131,6 +132,9 @@ func (a *addOnAgent) Manifests(cluster *clusterv1.ManagedCluster, addon *addonap
 		AddonInstallNamespace string
 		Image                 string
 		HubHost               string
+		OpenShiftProfile      string
+		OpenShiftProfileHost  string
+		OpenShiftProfilePort  string
 		NodeSelector          map[string]string
 		Tolerations           []corev1.Toleration
 	}{
@@ -139,6 +143,9 @@ func (a *addOnAgent) Manifests(cluster *clusterv1.ManagedCluster, addon *addonap
 		ClusterName:           cluster.Name,
 		Image:                 a.agentImage,
 		HubHost:               a.hubHost,
+		OpenShiftProfile:      os.Getenv("OPENSHIFT_PROFILE"),
+		OpenShiftProfileHost:  os.Getenv("OPENSHIFT_PROFILE_HOST"),
+		OpenShiftProfilePort:  os.Getenv("OPENSHIFT_PROFILE_PORT"),
 		NodeSelector:          make(map[string]string),
 		Tolerations:           make([]corev1.Toleration, 0),
 	}

--- a/pkg/hub/submarineraddonagent/manifests/deployment.yaml
+++ b/pkg/hub/submarineraddonagent/manifests/deployment.yaml
@@ -22,6 +22,18 @@ spec:
         env:
         - name: HUB_HOST
           value: "{{ .HubHost }}"
+        {{- if .OpenShiftProfile }}
+        - name: OPENSHIFT_PROFILE
+          value: "{{ .OpenShiftProfile }}"
+          {{- if .OpenShiftProfileHost }}
+        - name: OPENSHIFT_PROFILE_HOST
+          value: "{{ .OpenShiftProfileHost }}"
+          {{- end }}
+          {{- if .OpenShiftProfilePort }}
+        - name: OPENSHIFT_PROFILE_PORT
+          value: "{{ .OpenShiftProfilePort }}"
+          {{- end }}
+        {{- end }}
         args:
           - "/submariner"
           - "agent"


### PR DESCRIPTION
This applies hub settings to the addon on the spoke. This allows profiling endpoints to be enabled by enabling them on the hub; otherwise the hub-controlled deployments override any configuration set on the spokes.