### PR TITLE
Add OLM manifest YAML file for ClusterManagementAddOn

### DIFF
--- a/deploy/olm-catalog/manifests/submarineraddon.cluster-management-addon.yaml
+++ b/deploy/olm-catalog/manifests/submarineraddon.cluster-management-addon.yaml
@@ -1,0 +1,17 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  finalizers:
+    - submarineraddon.open-cluster-management.io/submariner-addon-cleanup
+  name: submariner
+spec:
+  addOnConfiguration: {}
+  addOnMeta:
+    description: Submariner Addon for MultiCluster connectivity
+    displayName: Submariner Addon
+  installStrategy:
+    type: Manual
+  supportedConfigs:
+    - group: addon.open-cluster-management.io
+      resource: addondeploymentconfigs
+

--- a/test/integration/deploying_addonagent_test.go
+++ b/test/integration/deploying_addonagent_test.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/rand"
-	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 )
 
 const (
@@ -109,44 +108,6 @@ var _ = Describe("Submariner addon agent", func() {
 
 				return meta.IsStatusConditionTrue(addOn.Status.Conditions, "SubmarinerConnectionDegraded")
 			}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
-		})
-	})
-
-	When("the ClusterManagementAddOn already exists when the submariner addon agent is deployed", func() {
-		BeforeEach(func() {
-			_, err := addOnClient.AddonV1alpha1().ClusterManagementAddOns().Create(context.Background(),
-				&addonv1alpha1.ClusterManagementAddOn{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: constants.SubmarinerAddOnName,
-					},
-					Spec: addonv1alpha1.ClusterManagementAddOnSpec{
-						InstallStrategy: addonv1alpha1.InstallStrategy{
-							Type: addonv1alpha1.AddonInstallStrategyManual,
-						},
-					},
-				},
-				metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			DeferCleanup(startControllerManager())
-		})
-
-		It("should update the ClusterManagementAddOn", func() {
-			var (
-				cma *addonv1alpha1.ClusterManagementAddOn
-				err error
-			)
-
-			Eventually(func() []string {
-				cma, err = addOnClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(),
-					constants.SubmarinerAddOnName, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				return cma.Finalizers
-			}, eventuallyTimeout, eventuallyInterval).ShouldNot(BeEmpty())
-
-			Expect(cma.Spec.AddOnMeta.DisplayName).ToNot(BeEmpty())
-			Expect(cma.Spec.SupportedConfigs).ToNot(BeEmpty())
 		})
 	})
 })


### PR DESCRIPTION
The MultiClusterHub operator will pick up this file and handle creating/updating the `ClusterManagementAddOn` in install/re-install. We no longer need to create it in code.

This is part of  story https://issues.redhat.com/browse/ACM-9341