### PR TITLE
Removed installstrategy from CMA spec

### DIFF
--- a/deploy/olm-catalog/manifests/submarineraddon.cluster-management-addon.yaml
+++ b/deploy/olm-catalog/manifests/submarineraddon.cluster-management-addon.yaml
@@ -9,8 +9,6 @@ spec:
   addOnMeta:
     description: Submariner Addon for MultiCluster connectivity
     displayName: Submariner Addon
-  installStrategy:
-    type: Manual
   supportedConfigs:
     - group: addon.open-cluster-management.io
       resource: addondeploymentconfigs

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -243,6 +243,11 @@ func createClusterManagementAddOn(ctx context.Context) {
 
 	cma := &addonv1alpha1.ClusterManagementAddOn{}
 	err = yaml.Unmarshal(data, cma)
+
+	// Adding installStrategy for testing purposes.
+	cma.Spec.InstallStrategy = addonv1alpha1.InstallStrategy{
+		Type: "manual",
+	}
 	Expect(err).To(Succeed())
 
 	o, err := addOnClient.AddonV1alpha1().ClusterManagementAddOns().Create(ctx, cma, metav1.CreateOptions{})

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -246,8 +246,9 @@ func createClusterManagementAddOn(ctx context.Context) {
 
 	// Adding installStrategy for testing purposes.
 	cma.Spec.InstallStrategy = addonv1alpha1.InstallStrategy{
-		Type: "manual",
+		Type: "Manual",
 	}
+
 	Expect(err).To(Succeed())
 
 	o, err := addOnClient.AddonV1alpha1().ClusterManagementAddOns().Create(ctx, cma, metav1.CreateOptions{})


### PR DESCRIPTION
Removing the `.spec.installStrategy` from the `ClusterManagementAddOn` resource. By default, this field is added when the resource is created. To prevent issues, we will remove this field for MCH to pickup and deploy properly.

```bash
2024-01-18T23:48:43Z	INFO	reconcile	failed to create typed patch object: .spec.installStrategy: field not declared in schema
```