### PR TITLE
update-csv should not delete the CMA yaml file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ demo:
 	scripts/demo.sh
 
 update-csv: ensure-operator-sdk
-	cd deploy && rm -rf olm-catalog/manifests && ../$(OPERATOR_SDK) generate bundle --manifests --deploy-dir config/ --crds-dir config/crds/ --output-dir olm-catalog/ --version $(CSV_VERSION)
+	cd deploy && rm olm-catalog/manifests/*clusterserviceversion.yaml olm-catalog/manifests/*submarinerconfigs.yaml olm-catalog/manifests/*submarinerdiagnoseconfigs.yaml && ../$(OPERATOR_SDK) generate bundle --manifests --deploy-dir config/ --crds-dir config/crds/ --output-dir olm-catalog/ --version $(CSV_VERSION)
 	rm ./deploy/olm-catalog/manifests/submariner-addon_v1_serviceaccount.yaml
 
 update-scripts:


### PR DESCRIPTION
The make target first deletes the entire _deploy/olm-catalog/manifests_ dir to remove the generated files but the dir now contains the static _submarineraddon.cluster-management-addon.yaml_ file which we don't want deleted. This causes the `verify` job to fail. So only delete the generated files.