### PR TITLE
Raise the addon memory limits to 1G

### DIFF
--- a/deploy/config/operator/operator.yaml
+++ b/deploy/config/operator/operator.yaml
@@ -40,7 +40,7 @@ spec:
             cpu: 100m
             memory: 128Mi
           limits:
-            memory: 270Mi
+            memory: 1024Mi
         env:
           - name: POD_NAME
             valueFrom:

--- a/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
@@ -313,7 +313,7 @@ spec:
                   initialDelaySeconds: 2
                 resources:
                   limits:
-                    memory: 270Mi
+                    memory: 1024Mi
                   requests:
                     cpu: 100m
                     memory: 128Mi


### PR DESCRIPTION
The limits were chosen based on basic tests; they aren’t sufficient in various production scenarios. Pending actual scale testing which will help determine accurate limits, this raises the limit to 1G which should be enough for common clusterset sizes.

Signed-off-by: Stephen Kitt <skitt@redhat.com>
(cherry picked from commit 8f5c3685898ab4e99dd5d637193c1f21b9dc2620)