### PR TITLE
Depbot config to limit main to target release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,11 @@ updates:
       # These are included with submariner-operator
       - dependency-name: github.com/submariner-io/admiral
       - dependency-name: github.com/submariner-io/submariner 
+      # Currently main syncs to release-2.10 which tracks 0.17.* Update when main syncs to release-2.11
+      - dependency-name: github.com/submariner-io/submariner-operator
+        versions: ">= 0.18.0-m0"
+      - dependency-name: github.com/submariner-io/cloud-prepare
+        versions: ">= 0.18.0-m0"
   - package-ecosystem: gomod
     target-branch: "release-2.7"
     directory: "/"


### PR DESCRIPTION
Current main branch is synced to release-2.10 which should be limited to upstream versions release-0.17.x*. Upstream devel is already on 0.18.0-m0 which shouldn't be pulled till release-2.11 branch is created.

This patch is to limit main to 0.17.x and will need to be updated once release-2.11 is created.