### PR TITLE
Add Dockerfile for Konflux, use by default

### DIFF
--- a/.tekton/submariner-addon-acm-210-pull-request.yaml
+++ b/.tekton/submariner-addon-acm-210-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: Dockerfile
+    value: Dockerfile.konflux
   - name: git-url
     value: '{{source_url}}'
   - name: image-expires-after

--- a/.tekton/submariner-addon-acm-210-push.yaml
+++ b/.tekton/submariner-addon-acm-210-push.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: Dockerfile
+    value: Dockerfile.konflux
   - name: git-url
     value: '{{source_url}}'
   - name: output-image

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,0 +1,9 @@
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.21 AS builder
+WORKDIR /go/src/github.com/stolostron/submariner-addon
+COPY . .
+ENV GO_PACKAGE github.com/stolostron/submariner-addon
+RUN make build --warn-undefined-variables
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+COPY --from=builder /go/src/github.com/stolostron/submariner-addon/submariner /
+RUN microdnf update && microdnf clean all

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOHOSTOS ?=$(shell $(GO) env GOHOSTOS)
 GOHOSTARCH ?=$(shell $(GO) env GOHOSTARCH)
 GO_FILES ?=$(shell find . -name '*.go' -not -path '*/vendor/*' -not -path '*/_output/*' -print)
 go_files_count :=$(words $(GO_FILES))
-GO_BUILD_FLAGS ?=-trimpath
+GO_BUILD_FLAGS ?=-trimpath -mod=mod
 
 SOURCE_GIT_TAG ?=$(shell git describe --long --tags --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown-$(SOURCE_GIT_COMMIT)')
 SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)
@@ -52,7 +52,7 @@ endif
 
 images: ensure-imagebuilder
 	$(strip imagebuilder $(IMAGE_BUILD_DEFAULT_FLAGS) $(IMAGE_BUILD_EXTRA_FLAGS) \
-		-t $(IMAGE_REGISTRY)/$(IMAGE) -f ./Dockerfile . \
+		-t $(IMAGE_REGISTRY)/$(IMAGE) -f ./Dockerfile.konflux . \
 	)
 
 ensure-imagebuilder:


### PR DESCRIPTION
Explicitly don't use vendoring or Konflux will fail on the ambiguity.

Relates-to: https://issues.redhat.com/browse/ACM-10822