### PR TITLE
Revert to non-Konflux builds by default

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -2,7 +2,7 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.21 AS bui
 WORKDIR /go/src/github.com/stolostron/submariner-addon
 COPY . .
 ENV GO_PACKAGE github.com/stolostron/submariner-addon
-RUN make build --warn-undefined-variables
+RUN make GO_BUILD_FLAGS=-mod=mod build --warn-undefined-variables
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=builder /go/src/github.com/stolostron/submariner-addon/submariner /

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOHOSTOS ?=$(shell $(GO) env GOHOSTOS)
 GOHOSTARCH ?=$(shell $(GO) env GOHOSTARCH)
 GO_FILES ?=$(shell find . -name '*.go' -not -path '*/vendor/*' -not -path '*/_output/*' -print)
 go_files_count :=$(words $(GO_FILES))
-GO_BUILD_FLAGS ?=-trimpath -mod=mod
+GO_BUILD_FLAGS += -trimpath
 
 SOURCE_GIT_TAG ?=$(shell git describe --long --tags --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown-$(SOURCE_GIT_COMMIT)')
 SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)
@@ -23,6 +23,7 @@ IMAGE_REGISTRY ?= quay.io/stolostron
 GIT_HOST ?= github.com/stolostron
 BASE_DIR := $(shell basename $(PWD))
 DEST := $(GOPATH)/src/$(GIT_HOST)/$(BASE_DIR)
+DOCKERFILE ?= ./Dockerfile
 
 # CSV_VERSION is used to generate new CSV manifests
 CSV_VERSION?=0.4.0
@@ -52,7 +53,7 @@ endif
 
 images: ensure-imagebuilder
 	$(strip imagebuilder $(IMAGE_BUILD_DEFAULT_FLAGS) $(IMAGE_BUILD_EXTRA_FLAGS) \
-		-t $(IMAGE_REGISTRY)/$(IMAGE) -f ./Dockerfile.konflux . \
+		-t $(IMAGE_REGISTRY)/$(IMAGE) -f $(DOCKERFILE) . \
 	)
 
 ensure-imagebuilder:


### PR DESCRIPTION
Konflux builds seem to rely on Tekton directives rather than the Makefile. Brew-based container builds are now failing, either because of the switch to Dockerfile.konflux by default, or the use of -mod=mod. To re-enable Brew-based builds, control the latter from Dockerfile.konflux, and default to Dockerfile from the Makefile. The Tekton build configuration explicitly refers to Dockerfile.konflux so this shouldn't affect Konflux builds.