### PR TITLE
Update ubi version from 8 to 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ COPY . .
 ENV GO_PACKAGE github.com/stolostron/submariner-addon
 RUN make build --warn-undefined-variables
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=builder /go/src/github.com/stolostron/submariner-addon/submariner /
 RUN microdnf update && microdnf clean all


### PR DESCRIPTION
Update ubi version from 8 to 9 to fix submariner-addon fails to start issue.

submariner-addon pods fail to start in ACM 2.12.

This error is reported.

/submariner: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by /submariner)
/submariner: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /submariner)