### PR TITLE
Get local-cluster by label

### DIFF
--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -127,7 +127,7 @@ var _ = BeforeSuite(func() {
 	}
 
 	// create local cluster with URL in ClientConfig
-	localCluster := util.NewManagedCluster("local-cluster", map[string]string{})
+	localCluster := util.NewManagedCluster("cluster-local", map[string]string{"local-cluster": "true"})
 	localCluster.Spec.ManagedClusterClientConfigs = []clusterV1.ClientConfig{
 		{
 			URL: "https://dummy:443",


### PR DESCRIPTION
Local cluster name can now be configured and is no longer hardcoded to `local-cluster` Use label `local-cluster=true` to get local cluster.