### PR TITLE
Add option to skip cloud prepare

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/openshift/library-go/pkg/operator/events"
 	configv1alpha1 "github.com/stolostron/submariner-addon/pkg/apis/submarinerconfig/v1alpha1"
@@ -77,6 +78,10 @@ func NewProviderFactory(restMapper meta.RESTMapper, kubeClient kubernetes.Interf
 }
 
 func (f *providerFactory) Get(config *configv1alpha1.SubmarinerConfig, eventsRecorder events.Recorder) (Provider, bool, error) {
+	if config.Annotations["submariner.io/skip-cloud-prepare"] == strconv.FormatBool(true) {
+		return nil, false, nil
+	}
+
 	managedClusterInfo := &config.Status.ManagedClusterInfo
 
 	klog.V(4).Infof("Get cloud provider: ManagedClusterInfo: %#v", managedClusterInfo)

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -2,6 +2,7 @@ package cloud_test
 
 import (
 	"context"
+	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -134,6 +135,19 @@ var _ = Describe("ProviderFactory Get", func() {
 				_, _, err := providerFactory.Get(submarinerConfig, events.NewLoggingEventRecorder("test"))
 				Expect(err).To(HaveOccurred())
 			})
+		})
+	})
+
+	When("skip prepare is enabled", func() {
+		BeforeEach(func() {
+			submarinerConfig.Annotations = map[string]string{"submariner.io/skip-cloud-prepare": strconv.FormatBool(true)}
+		})
+
+		It("should return false", func() {
+			provider, found, err := providerFactory.Get(submarinerConfig, events.NewLoggingEventRecorder("test"))
+			Expect(err).To(Succeed())
+			Expect(found).To(BeFalse())
+			Expect(provider).To(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
It may be necessary to skip cloud prepare in some installations, eg to temporarily work around an issue. Introduce a backdoor way to do this via an annotation on the `SubmarinerConfig`.