### PR TITLE
Remove '$ref' statements in the SubmarinerConfig schema

### DIFF
--- a/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -65,7 +65,6 @@ spec:
                 description: CableDriver represents the submariner cable driver implementation. Available options are libreswan (default) strongswan, wireguard, and vxlan.
                 type: string
               credentialsSecret:
-                $ref: '#/definitions/k8s.io~1api~1core~1v1~0LocalObjectReference'
                 description: CredentialsSecret is a reference to the secret with a certain cloud platform credentials, the supported platform includes AWS, GCP, Azure, ROKS and OSD. The submariner-addon will use these credentials to prepare Submariner cluster environment. If the submariner cluster environment requires submariner-addon preparation, this field should be specified.
               forceUDPEncaps:
                 default: false

--- a/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -63,7 +63,6 @@ spec:
                 description: CableDriver represents the submariner cable driver implementation. Available options are libreswan (default) strongswan, wireguard, and vxlan.
                 type: string
               credentialsSecret:
-                $ref: '#/definitions/k8s.io~1api~1core~1v1~0LocalObjectReference'
                 description: CredentialsSecret is a reference to the secret with a certain cloud platform credentials, the supported platform includes AWS, GCP, Azure, ROKS and OSD. The submariner-addon will use these credentials to prepare Submariner cluster environment. If the submariner cluster environment requires submariner-addon preparation, this field should be specified.
               forceUDPEncaps:
                 default: false


### PR DESCRIPTION
These are added by the generator tool but are not supported by K8s.