### PR TITLE
Updated credentialsSecret field in the SubmarinerConfig schema

### DIFF
--- a/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -66,6 +66,11 @@ spec:
                 type: string
               credentialsSecret:
                 description: CredentialsSecret is a reference to the secret with a certain cloud platform credentials, the supported platform includes AWS, GCP, Azure, ROKS and OSD. The submariner-addon will use these credentials to prepare Submariner cluster environment. If the submariner cluster environment requires submariner-addon preparation, this field should be specified.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
               forceUDPEncaps:
                 default: false
                 description: ForceUDPEncaps forces UDP Encapsulation for IPSec.

--- a/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -64,6 +64,11 @@ spec:
                 type: string
               credentialsSecret:
                 description: CredentialsSecret is a reference to the secret with a certain cloud platform credentials, the supported platform includes AWS, GCP, Azure, ROKS and OSD. The submariner-addon will use these credentials to prepare Submariner cluster environment. If the submariner cluster environment requires submariner-addon preparation, this field should be specified.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
               forceUDPEncaps:
                 default: false
                 description: ForceUDPEncaps forces UDP Encapsulation for IPSec.


### PR DESCRIPTION
In this PR: https://github.com/stolostron/submariner-addon/pull/1664, the `type` and `properties` field was removed from the `credentialsSecret` field in the `SubmarinerConfig` CRD schema. This PR is to add it back so the CRD can be deployed properly in MCH.