### PR TITLE
Dockerfile: confirm microdnf update automatically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN make build --warn-undefined-variables
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 COPY --from=builder /go/src/github.com/stolostron/submariner-addon/submariner /
-RUN microdnf update && microdnf clean all
+RUN microdnf update -y && microdnf clean all

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -6,4 +6,4 @@ RUN make GO_BUILD_FLAGS=-mod=mod build --warn-undefined-variables
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=builder /go/src/github.com/stolostron/submariner-addon/submariner /
-RUN microdnf update && microdnf clean all
+RUN microdnf update -y && microdnf clean all


### PR DESCRIPTION
microdnf gets stuck when the build runs interactively. Specifying "-y" avoids any prompting and allows the build to complete.