### PR TITLE
Orphan installation namespace for the addon deploy ManifestWorks

### DIFF
--- a/pkg/hub/submarineraddonagent/manifests/namespace.yaml
+++ b/pkg/hub/submarineraddonagent/manifests/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .AddonInstallNamespace }}
+  annotations:
+    addon.open-cluster-management.io/deletion-orphan: "true"

--- a/test/integration/deploying_submariner_test.go
+++ b/test/integration/deploying_submariner_test.go
@@ -189,26 +189,20 @@ var _ = Describe("Submariner Deployment", func() {
 
 func awaitSubmarinerManifestWorks(managedClusterName string) {
 	By("Await deployment of the ManifestWorks")
-	Eventually(func() bool {
-		return util.CheckManifestWorks(workClient, managedClusterName, true, submarineragent.OperatorManifestWorkName,
-			submarineragent.SubmarinerCRManifestWorkName)
-	}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
+	awaitManifestWorks(workClient, managedClusterName, submarineragent.OperatorManifestWorkName,
+		submarineragent.SubmarinerCRManifestWorkName)
 }
 
 func ensureSubmarinerManifestWorks(managedClusterName string) {
 	By("Ensure deployment of the ManifestWorks")
-	Consistently(func() bool {
-		return util.CheckManifestWorks(workClient, managedClusterName, true, submarineragent.OperatorManifestWorkName,
-			submarineragent.SubmarinerCRManifestWorkName)
-	}, 1).Should(BeTrue())
+	awaitManifestWorks(workClient, managedClusterName, submarineragent.OperatorManifestWorkName,
+		submarineragent.SubmarinerCRManifestWorkName)
 }
 
 func awaitNoSubmarinerManifestWorks(managedClusterName string) {
 	By("Await deletion of the ManifestWorks")
-	Eventually(func() bool {
-		return util.CheckManifestWorks(workClient, managedClusterName, false, submarineragent.OperatorManifestWorkName,
-			submarineragent.SubmarinerCRManifestWorkName)
-	}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
+	awaitNoManifestWorks(workClient, managedClusterName, submarineragent.OperatorManifestWorkName,
+		submarineragent.SubmarinerCRManifestWorkName)
 }
 
 func createBrokerConfiguration(brokerNamespace string) {


### PR DESCRIPTION
The addon controller is deployed in the same namespace (defaults to "submariner-operator") as the Submariner components on the spoke cluster. The `ManifestWorks` deploys the `Namespace` resource as well to ensure it's created when deploying the other resources however we don't want the `ManifestWorks` to delete the `Namespace` on uninstall to avoid a race condition where the Submariner operator pod is deleted before it is able to run cleanup and remove its finalizer from the Submariner resource.

Set the` addon.open-cluster-management.io/deletion-orphan` annotation on the Namespace resource so the addon framework configures the `ManifestWorks` to orphan it.

See https://issues.redhat.com/browse/ACM-15538 for more details.