### PR TITLE
Add operator Namespace to the Subscription manifest work

### DIFF
--- a/pkg/hub/submarineragent/controller.go
+++ b/pkg/hub/submarineragent/controller.go
@@ -71,6 +71,7 @@ const (
 	SubmarinerCRManifestWorkName  = "submariner-resource"
 	agentRBACFile                 = "manifests/rbac/operatorgroup-aggregate-clusterrole.yaml"
 	submarinerCRFile              = "manifests/operator/submariner.io-submariners-cr.yaml"
+	operatorNamespaceFile         = "manifests/operator/submariner-operator-namespace.yaml"
 	BrokerCfgApplied              = "SubmarinerBrokerConfigApplied"
 	BrokerObjectName              = "submariner-broker"
 	BackupLabelKey                = "cluster.open-cluster-management.io/backup"
@@ -620,7 +621,7 @@ func newSubmarinerManifestWork(managedCluster *clusterv1.ManagedCluster, config 
 
 func newOperatorManifestWork(managedCluster *clusterv1.ManagedCluster, config interface{}, skipOperatorGroup bool,
 ) (*workv1.ManifestWork, error) {
-	files := []string{agentRBACFile}
+	files := []string{operatorNamespaceFile, agentRBACFile}
 	clusterProduct := getClusterProduct(managedCluster)
 	if clusterProduct == constants.ProductOCP || clusterProduct == constants.ProductROSA ||
 		clusterProduct == constants.ProductARO || clusterProduct == constants.ProductROKS {

--- a/pkg/hub/submarineragent/controller_test.go
+++ b/pkg/hub/submarineragent/controller_test.go
@@ -765,6 +765,8 @@ func (t *testDriver) assertOperatorManifestWork(work *workv1.ManifestWork) []*un
 
 	assertNoManifestObj(manifestObjs, "Submariner", "")
 
+	assertManifestObj(manifestObjs, "Namespace", installNamespace)
+
 	subscription := assertManifestObj(manifestObjs, "Subscription", "")
 	assertNestedString(subscription, installNamespace, "metadata", "namespace")
 	assertNestedString(subscription, "submariner", "spec", "name")

--- a/pkg/hub/submarineragent/manifests/operator/submariner-operator-namespace.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner-operator-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .InstallationNamespace }}


### PR DESCRIPTION
...so the namespace is deleted on clean up. The namesapce used to get deleted via the agent add-on manifest work but that was removed b/c it interfered with submariner cleanup on the managed clusters. It was thought that deleting the Subscription would cause the installed operator components to be deleted but that's not the case - deleting a Subscription only unsubscribes from future updates and leaves the installation intact.

Related to https://issues.redhat.com/browse/ACM-16491