### PR TITLE
Bump golangci-lint to 1.63.4 and adjust

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
+    - copyloopvar
     # - cyclop # This is equivalent to gocyclo
     - decorder
     # - depguard # depguard now denies by default, it should only be enabled if we actually use it
@@ -36,6 +37,7 @@ linters:
     - dupl
     - dupword
     - durationcheck
+    - err113
     - errcheck
     - errchkjson
     - errorlint
@@ -43,7 +45,6 @@ linters:
     # - execinquery # No SQL
     - exhaustive
     # - exhauststruct # Not recommended for general use - meant to be used only for special cases
-    - exportloopref
     # - forbidigo # We don't forbid any statements
     # - forcetypeassert # There are many unchecked type assertions that would be the result of a programming error so the
     #                     reasonable recourse would be to panic anyway if checked so this doesn't seem useful
@@ -56,7 +57,6 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    - goerr113
     - godot
     # - godox #  Let's not forbid inline TODOs, FIXMEs et al
     - gofmt
@@ -167,6 +167,6 @@ issues:
     # https://github.com/Djarvur/go-err113/issues/10 for an interesting discussion of this error. While there are cases
     # where wrapped sentinel errors are useful, it seems a bit pedantic to force that pattern in all cases.
     - linters:
-        - goerr113
+        - err113
       text: "do not define dynamic errors"
 

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
-GOLANGCI_LINT_VERSION=v1.54.2
+GOLANGCI_LINT_VERSION=v1.63.4
 GOLANGCI_LINT?=$(PERMANENT_TMP_GOPATH)/bin/golangci-lint
 
 $(GOLANGCI_LINT):

--- a/cmd/submariner/main.go
+++ b/cmd/submariner/main.go
@@ -43,7 +43,7 @@ func newSubmarinerControllerCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "submariner",
 		Short: "submariner-addon",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			_ = cmd.Help()
 			os.Exit(1)
 		},

--- a/pkg/cloud/aws/aws.go
+++ b/pkg/cloud/aws/aws.go
@@ -123,8 +123,8 @@ func (a *awsProvider) PrepareSubmarinerClusterEnv() error {
 	// For now we only support at least one gateway (no load-balancer)
 	if err := a.gatewayDeployer.Deploy(cpapi.GatewayDeployInput{
 		PublicPorts: []cpapi.PortSpec{
-			{Port: uint16(a.nattPort), Protocol: "udp"},
-			{Port: uint16(a.nattDiscoveryPort), Protocol: "udp"},
+			{Port: uint16(a.nattPort), Protocol: "udp"},          //nolint:gosec // Valid port numbers fit in 16 bits
+			{Port: uint16(a.nattDiscoveryPort), Protocol: "udp"}, //nolint:gosec // Valid port numbers fit in 16 bits
 			// ESP & AH protocols are used for private-ip to private-ip gateway communications
 			{Port: 0, Protocol: "50"},
 			{Port: 0, Protocol: "51"},

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -86,7 +86,7 @@ func NewProvider(info *provider.Info) (*azureProvider, error) {
 
 	return &azureProvider{
 		infraID:           info.InfraID,
-		nattPort:          uint16(info.IPSecNATTPort),
+		nattPort:          uint16(info.IPSecNATTPort), //nolint:gosec // Valid port numbers fit in 16 bits
 		cniType:           info.NetworkType,
 		cloudPrepare:      cloudPrepare,
 		gwDeployer:        gwDeployer,
@@ -108,7 +108,7 @@ func (r *azureProvider) PrepareSubmarinerClusterEnv() error {
 	if err := r.gwDeployer.Deploy(api.GatewayDeployInput{
 		PublicPorts: []api.PortSpec{
 			{Port: r.nattPort, Protocol: "udp"},
-			{Port: uint16(r.nattDiscoveryPort), Protocol: "udp"},
+			{Port: uint16(r.nattDiscoveryPort), Protocol: "udp"}, //nolint:gosec // Valid port numbers fit in 16 bits
 			{Port: 0, Protocol: "esp"},
 			{Port: 0, Protocol: "ah"},
 		},

--- a/pkg/cloud/gcp/gcp.go
+++ b/pkg/cloud/gcp/gcp.go
@@ -76,7 +76,7 @@ func NewProvider(info *provider.Info) (*gcpProvider, error) {
 
 	return &gcpProvider{
 		infraID:           info.InfraID,
-		nattPort:          uint16(info.IPSecNATTPort),
+		nattPort:          uint16(info.IPSecNATTPort), //nolint:gosec // Valid port numbers fit in 16 bits
 		cniType:           info.NetworkType,
 		cloudPrepare:      cloudPrepare,
 		gwDeployer:        gwDeployer,
@@ -96,7 +96,7 @@ func (g *gcpProvider) PrepareSubmarinerClusterEnv() error {
 	if err := g.gwDeployer.Deploy(api.GatewayDeployInput{
 		PublicPorts: []api.PortSpec{
 			{Port: g.nattPort, Protocol: "udp"},
-			{Port: uint16(g.nattDiscoveryPort), Protocol: "udp"},
+			{Port: uint16(g.nattDiscoveryPort), Protocol: "udp"}, //nolint:gosec // Valid port numbers fit in 16 bits
 			// ESP & AH protocols are used for private-ip to private-ip gateway communications
 			{Port: 0, Protocol: "esp"},
 			{Port: 0, Protocol: "ah"},

--- a/pkg/cloud/rhos/rhos.go
+++ b/pkg/cloud/rhos/rhos.go
@@ -79,7 +79,7 @@ func NewProvider(info *provider.Info) (*rhosProvider, error) {
 
 	return &rhosProvider{
 		infraID:           info.InfraID,
-		nattPort:          uint16(info.IPSecNATTPort),
+		nattPort:          uint16(info.IPSecNATTPort), //nolint:gosec // Valid port numbers fit in 16 bits
 		cniType:           info.NetworkType,
 		cloudPrepare:      cloudPrepare,
 		gwDeployer:        gwDeployer,
@@ -99,7 +99,7 @@ func (r *rhosProvider) PrepareSubmarinerClusterEnv() error {
 	if err := r.gwDeployer.Deploy(api.GatewayDeployInput{
 		PublicPorts: []api.PortSpec{
 			{Port: r.nattPort, Protocol: "udp"},
-			{Port: uint16(r.nattDiscoveryPort), Protocol: "udp"},
+			{Port: uint16(r.nattDiscoveryPort), Protocol: "udp"}, //nolint:gosec // Valid port numbers fit in 16 bits
 			{Port: 0, Protocol: "esp"},
 			{Port: 0, Protocol: "ah"},
 		},

--- a/pkg/spoke/submarineragent/config_controller_test.go
+++ b/pkg/spoke/submarineragent/config_controller_test.go
@@ -330,6 +330,7 @@ func testSubmarinerConfig(t *configControllerTestDriver) {
 
 			BeforeEach(func() {
 				waitCh = make(chan struct{})
+
 				gomock.InOrder(
 					t.cloudProvider.EXPECT().PrepareSubmarinerClusterEnv().Return(errors.New("fake error")).Times(1),
 					t.cloudProvider.EXPECT().PrepareSubmarinerClusterEnv().DoAndReturn(func() error {
@@ -524,6 +525,7 @@ func testManagedClusterAddOn(t *configControllerTestDriver) {
 
 				BeforeEach(func() {
 					waitCh = make(chan struct{})
+
 					gomock.InOrder(
 						t.cloudProvider.EXPECT().CleanUpSubmarinerClusterEnv().Return(errors.New("fake error")).Times(1),
 						t.cloudProvider.EXPECT().CleanUpSubmarinerClusterEnv().DoAndReturn(func() error {

--- a/pkg/spoke/submarineragent/config_controller_test.go
+++ b/pkg/spoke/submarineragent/config_controller_test.go
@@ -368,6 +368,16 @@ func testSubmarinerConfig(t *configControllerTestDriver) {
 			t.awaitGatewaysLabeledSuccessCondition()
 		})
 	})
+
+	When("the SubmarinerConfig requests fewer than one gateway", func() {
+		BeforeEach(func() {
+			t.config.Spec.Gateways = 0
+		})
+
+		It("should report an invalid input condition", func() {
+			t.awaitGatewaysLabeledInvalidInputCondition()
+		})
+	})
 }
 
 func testManagedClusterAddOn(t *configControllerTestDriver) {
@@ -687,6 +697,14 @@ func (t *configControllerTestDriver) awaitGatewaysLabeledFailureCondition() {
 		Type:   gatewayConditionType,
 		Status: metav1.ConditionFalse,
 		Reason: "Failure",
+	})
+}
+
+func (t *configControllerTestDriver) awaitGatewaysLabeledInvalidInputCondition() {
+	t.awaitSubmarinerConfigStatusCondition(&metav1.Condition{
+		Type:   gatewayConditionType,
+		Status: metav1.ConditionFalse,
+		Reason: "InvalidInput",
 	})
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -35,7 +35,7 @@ func Get() version.Info {
 
 func init() {
 	buildInfo := metrics.NewGaugeVec(
-		&metrics.GaugeOpts{
+		&metrics.GaugeOpts{ //nolint:promlinter // False positive, the metric name is snake case as expected
 			Name: "open_cluster_management_submariner_addon_build_info",
 			Help: "A metric with a constant '1' value labeled by major, minor, git commit & git version from which Open Cluster Management " +
 				"submariner-addon was built.",

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -124,10 +124,11 @@ func SetupServiceAccount(kubeClient kubernetes.Interface, namespace, name string
 		func(ctx context.Context) (bool, error) {
 			// add a token secret to serviceaccount
 			sa, err := kubeClient.CoreV1().ServiceAccounts(namespace).Get(ctx, name, metav1.GetOptions{})
-			if errors.IsNotFound(err) {
-				return false, nil
-			}
 			if err != nil {
+				if errors.IsNotFound(err) {
+					return false, nil
+				}
+
 				return false, err
 			}
 

--- a/tools/genswaggertypedocs/swagger_type_docs.go
+++ b/tools/genswaggertypedocs/swagger_type_docs.go
@@ -55,9 +55,11 @@ func main() {
 		if err != nil {
 			klog.Fatalf("Couldn't search for files matching -s: %v", err)
 		}
+
 		if len(m) == 0 {
 			klog.Fatalf("-s must be a valid file or file glob pattern")
 		}
+
 		for _, file := range m {
 			docsForTypes = append(docsForTypes, kruntime.ParseDocumentationFrom(file)...)
 		}


### PR DESCRIPTION
* goerr113 is now err113
* exportloopref has been replaced by copyloopvar
* use _ for unused arguments
* ignore gosec warnings for uint16 casts on port numbers
* avoid unnecessary formatting calls on preformatted strings
* fix cuddling
* ignore promlinter false positive