### PR TITLE
De-duplicate Konflux and Dependabot updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    "group:kubernetes"
+  ],
+  "enabledManagers": ["gomod", "tekton"],
+  "packageRules": [
+    {
+      "description": "Disable all Go module updates by default",
+      "matchManagers": ["gomod"],
+      "enabled": false
+    },
+    {
+      "description": "Re-enable Kubernetes Go module updates",
+      "matchManagers": ["gomod"],
+      "groupSlug": "kubernetes-go",
+      "enabled": true
+    },
+    {
+      "description": "Re-enable Operator Framework Go module updates",
+      "matchManagers": ["gomod"],
+      "matchPackagePatterns": ["^github\\.com/operator-framework/"],
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
Let Konflux manage Tekton and Dependabot manage go modules.

We currently receive go module updates from both Dependabot and Konflux. Disable all go module updates from Konflux, then re-enable packages ignored in our Dependabot config to keep the same behavior.

The K8s group is defined here:

https://docs.renovatebot.com/presets-group/#groupkubernetes

Note that we have used Konflux's PRs to bump K8s.

https://github.com/stolostron/submariner-addon/pull/1883

Note that it doesn't seem like anything is causing operator-framework updates, as the current version on all branches is the same as when we configured Dependabot to ignore it.

https://github.com/stolostron/submariner-addon/pull/1634