### PR TITLE
Disable RenovateBot digest updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,9 @@
     "group:kubernetes"
   ],
   "enabledManagers": ["gomod", "tekton"],
+  "digest": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "description": "Disable all Go module updates by default",


### PR DESCRIPTION
Our digest dependencies are dependencies where we only care about the version pulled in by another, tagged, dependency; for example, we want the k8s.io/utils version matching the main k8s.io dependencies. Bumping these separately is usually counter-productive.