### PR TITLE
Fix ensure-controller-gen target in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 /submariner
+/bin
 
 # Test binary, built with `go test -c`
 *.test

--- a/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: submarinerconfigs.submarineraddon.open-cluster-management.io
 spec:
   group: submarineraddon.open-cluster-management.io

--- a/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerdiagnoseconfigs.yaml
+++ b/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerdiagnoseconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: submarinerdiagnoseconfigs.submarineraddon.open-cluster-management.io
 spec:
   group: submarineraddon.open-cluster-management.io

--- a/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.18.0
   creationTimestamp: null
   name: submarinerconfigs.submarineraddon.open-cluster-management.io
 spec:

--- a/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerdiagnoseconfigs.yaml
+++ b/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerdiagnoseconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.18.0
   creationTimestamp: null
   name: submarinerdiagnoseconfigs.submarineraddon.open-cluster-management.io
 spec:

--- a/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
+++ b/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: submarinerconfigs.submarineraddon.open-cluster-management.io
 spec:
   group: submarineraddon.open-cluster-management.io


### PR DESCRIPTION
Previously this did not work unless `controller-gen` was already present on the PATH. This isn't the case in CI which resulted in an error accessing `controller-gen` during the verify job, although it didn't fail the job. Use `go install` to build and install it in the local bin directory.