### PR TITLE
[release-2.17] Prefix broker cluster serviceaccount name with "cluster-"

### DIFF
--- a/pkg/hub/submarineragent/controller.go
+++ b/pkg/hub/submarineragent/controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/util"
 	submarinerv1a1 "github.com/submariner-io/submariner-operator/api/v1alpha1"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
+	"github.com/submariner-io/submariner-operator/pkg/names"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	discovery "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -120,6 +121,7 @@ var logger = log.Logger{Logger: logf.Log.WithName("SubmarinerAgentController")}
 
 type clusterRBACConfig struct {
 	ManagedClusterName        string
+	ClusterSAName             string
 	SubmarinerBrokerNamespace string
 }
 
@@ -582,6 +584,7 @@ func (c *submarinerAgentController) deleteManifestWork(ctx context.Context, name
 func (c *submarinerAgentController) applyClusterRBACFiles(ctx context.Context, brokerNamespace, managedClusterName string) error {
 	config := &clusterRBACConfig{
 		ManagedClusterName:        managedClusterName,
+		ClusterSAName:             names.ForClusterSA(managedClusterName),
 		SubmarinerBrokerNamespace: brokerNamespace,
 	}
 
@@ -591,8 +594,10 @@ func (c *submarinerAgentController) applyClusterRBACFiles(ctx context.Context, b
 }
 
 func (c *submarinerAgentController) removeClusterRBACFiles(ctx context.Context, managedClusterName string) error {
+	saName := names.ForClusterSA(managedClusterName)
+
 	serviceAccounts, err := c.kubeClient.CoreV1().ServiceAccounts(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", serviceAccountLabel, managedClusterName),
+		LabelSelector: fmt.Sprintf("%s=%s", serviceAccountLabel, saName),
 	})
 	if err != nil {
 		return errors.Wrap(err, "error listing ServiceAccounts")
@@ -609,7 +614,7 @@ func (c *submarinerAgentController) removeClusterRBACFiles(ctx context.Context, 
 
 	// Delete created secret if present
 	brokerNamespace := serviceAccounts.Items[0].Namespace
-	secretName := brokerinfo.GenerateBrokerName(managedClusterName)
+	secretName := brokerinfo.GenerateBrokerName(saName)
 	err = c.kubeClient.CoreV1().Secrets(brokerNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
 
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -618,6 +623,7 @@ func (c *submarinerAgentController) removeClusterRBACFiles(ctx context.Context, 
 
 	config := &clusterRBACConfig{
 		ManagedClusterName:        managedClusterName,
+		ClusterSAName:             saName,
 		SubmarinerBrokerNamespace: serviceAccounts.Items[0].Namespace,
 	}
 

--- a/pkg/hub/submarineragent/controller_test.go
+++ b/pkg/hub/submarineragent/controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/test"
 	submarinerv1alpha1 "github.com/submariner-io/submariner-operator/api/v1alpha1"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
+	"github.com/submariner-io/submariner-operator/pkg/names"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
@@ -648,7 +649,7 @@ func newTestDriver() *testDriver {
 			},
 			&corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName,
+					Name:      names.ForClusterSA(clusterName),
 					Namespace: brokerNamespace,
 				},
 			},
@@ -656,7 +657,7 @@ func newTestDriver() *testDriver {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        clusterName + "-token-5pw5c",
 					Namespace:   brokerNamespace,
-					Annotations: map[string]string{corev1.ServiceAccountNameKey: clusterName},
+					Annotations: map[string]string{corev1.ServiceAccountNameKey: names.ForClusterSA(clusterName)},
 				},
 				Data: map[string][]byte{
 					"ca.crt": []byte(brokerCA),
@@ -748,7 +749,7 @@ func (t *testDriver) testAgentCleanup(expMCADeleted bool) {
 
 	It("should delete the RBAC resources for the managed cluster", func() {
 		test.AwaitNoResource(coreresource.ForRoleBinding(t.kubeClient, brokerNamespace), "submariner-k8s-broker-cluster-"+clusterName)
-		test.AwaitNoResource(coreresource.ForServiceAccount(t.kubeClient, brokerNamespace), clusterName)
+		test.AwaitNoResource(coreresource.ForServiceAccount(t.kubeClient, brokerNamespace), names.ForClusterSA(clusterName))
 	})
 }
 
@@ -898,10 +899,10 @@ func (t *testDriver) awaitClusterRBACResources() {
 		"submariner-k8s-broker-cluster-"+clusterName)
 	Expect(roleBinding.Subjects).To(HaveLen(1))
 	Expect(roleBinding.Subjects[0].Kind).To(Equal("ServiceAccount"))
-	Expect(roleBinding.Subjects[0].Name).To(Equal(clusterName))
+	Expect(roleBinding.Subjects[0].Name).To(Equal(names.ForClusterSA(clusterName)))
 	Expect(roleBinding.Subjects[0].Namespace).To(Equal(brokerNamespace))
 
-	test.AwaitResource(coreresource.ForServiceAccount(t.kubeClient, brokerNamespace), clusterName)
+	test.AwaitResource(coreresource.ForServiceAccount(t.kubeClient, brokerNamespace), names.ForClusterSA(clusterName))
 }
 
 func (t *testDriver) assertSCCManifestObjs(objs []*unstructured.Unstructured) {

--- a/pkg/hub/submarineragent/manifests/rbac/broker-cluster-rolebinding.yaml
+++ b/pkg/hub/submarineragent/manifests/rbac/broker-cluster-rolebinding.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: submariner-k8s-broker-cluster
 subjects:
   - kind: ServiceAccount
-    name: {{ .ManagedClusterName }}
+    name: {{ .ClusterSAName }}
     namespace: {{ .SubmarinerBrokerNamespace }}

--- a/pkg/hub/submarineragent/manifests/rbac/broker-cluster-serviceaccount.yaml
+++ b/pkg/hub/submarineragent/manifests/rbac/broker-cluster-serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .ManagedClusterName }}
+  name: {{ .ClusterSAName }}
   namespace: {{ .SubmarinerBrokerNamespace }}
   labels:
-    cluster.open-cluster-management.io/submariner-cluster-sa: {{ .ManagedClusterName }}
+    cluster.open-cluster-management.io/submariner-cluster-sa: {{ .ClusterSAName }}

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo.go
@@ -15,6 +15,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
+	"github.com/submariner-io/submariner-operator/pkg/names"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -342,9 +343,11 @@ func getKubeAPIServerCA(ctx context.Context, kubeAPIServer string, kubeClient ku
 func getBrokerTokenAndCA(ctx context.Context, kubeClient kubernetes.Interface, dynamicClient dynamic.Interface,
 	brokerNS, clusterName, kubeAPIServer string,
 ) (string, string, error) {
-	sa, err := kubeClient.CoreV1().ServiceAccounts(brokerNS).Get(ctx, clusterName, metav1.GetOptions{})
+	saName := names.ForClusterSA(clusterName)
+
+	sa, err := kubeClient.CoreV1().ServiceAccounts(brokerNS).Get(ctx, saName, metav1.GetOptions{})
 	if err != nil {
-		return "", "", fmt.Errorf("failed to get agent ServiceAccount %v/%v: %w", brokerNS, clusterName, err)
+		return "", "", fmt.Errorf("failed to get agent ServiceAccount %v/%v: %w", brokerNS, saName, err)
 	}
 
 	tokenSecret, err := getTokenSecretForSA(ctx, kubeClient, sa)

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
@@ -11,6 +11,7 @@ import (
 	configv1alpha1 "github.com/stolostron/submariner-addon/pkg/apis/submarinerconfig/v1alpha1"
 	"github.com/stolostron/submariner-addon/pkg/hub/submarinerbrokerinfo"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
+	"github.com/submariner-io/submariner-operator/pkg/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -80,7 +81,7 @@ var _ = Describe("Function Get", func() {
 
 		serviceAccount = &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      clusterName,
+				Name:      names.ForClusterSA(clusterName),
 				Namespace: brokerNamespace,
 			},
 		}

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stolostron/submariner-addon/test/util"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
 	admutil "github.com/submariner-io/admiral/pkg/util"
+	"github.com/submariner-io/submariner-operator/pkg/names"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -211,7 +212,7 @@ func deployManagedClusterWithAddOn(managedClusterSetName, managedClusterName, br
 
 	By("Setup the service account")
 
-	err = util.SetupServiceAccount(kubeClient, brokerNamespace, managedClusterName)
+	err = util.SetupServiceAccount(kubeClient, brokerNamespace, names.ForClusterSA(managedClusterName))
 	Expect(err).NotTo(HaveOccurred())
 }
 


### PR DESCRIPTION
The new broker webhook expects broker SA names to be prefixed with "cluster-" so it can identify them to extract the cluster name for validation.

Updated:
- Broker serviceaccount and rolebinding YAML templates
- brokerinfo.go to use names.ForClusterSA() when retrieving SA
- Test files to use names.ForClusterSA() for assertions